### PR TITLE
AppBar, Card 컴포넌트 수정

### DIFF
--- a/components/Appbar/style.tsx
+++ b/components/Appbar/style.tsx
@@ -7,8 +7,10 @@ const Layout = styled.div`
   display: flex;
   justify-content: space-between;
   //아래 3속성: 상단 고정을 위함
-  position: absolute;
+  position: sticky;
   top: 0;
+  background-color: white;
+  z-index: 2;
   width: 100%;
 `;
 

--- a/components/Card/CardLayout/style.tsx
+++ b/components/Card/CardLayout/style.tsx
@@ -5,11 +5,10 @@ interface LayoutProps {
 }
 
 const Layout = styled.div<LayoutProps>`
-  //아래 2속성: 정렬
   width: ${(props) => props.size};
+  //아래 2속성: 정렬
   display: flex;
   flex-direction: column;
-  height: 225px;
   //아래 1속성: 카드 크기 확인을 위한 임시 속성
   box-sizing: content-box;
 `;

--- a/components/Card/MainTopUserCard/index.tsx
+++ b/components/Card/MainTopUserCard/index.tsx
@@ -1,12 +1,15 @@
 import { Body2, Headline2 } from '@/components/UI';
 import { CardComponentProps } from '../type';
 import Card from '../CardLayout';
+import { Layout } from './style';
 
 export default function MainTopClothCard(props: CardComponentProps) {
   return (
     <Card data={props.data} size="137px">
-      <Headline2>{props.headline}</Headline2>
-      <Body2>{props.body}</Body2>
+      <Layout>
+        <Headline2>{props.headline}</Headline2>
+        <Body2>{props.body}</Body2>
+      </Layout>
     </Card>
   );
 }

--- a/components/Card/MainTopUserCard/style.tsx
+++ b/components/Card/MainTopUserCard/style.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const Layout = styled.div`
+  padding: 8px 0 16px 4px;
+  h2 {
+    padding-bottom: 4px;
+  }
+`;
+
+export { Layout };

--- a/pages/name.tsx
+++ b/pages/name.tsx
@@ -30,7 +30,7 @@ import {
   AiOutlineUpload,
   AiOutlineSetting,
   AiFillGithub,
-} from 'react-icons/ai
+} from 'react-icons/ai';
 
 interface ComponentWithLayout extends FC {
   Layout?: FC<AppLayoutProps>;
@@ -86,6 +86,23 @@ const Name: ComponentWithLayout = () => {
         }}
         headline={'Headline4'}
         body={'Body2'}
+      />
+      <MainTopClothCard
+        data={{
+          src: 'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
+          alt: '카드',
+          caption: 'Tag',
+        }}
+        headline={'Headline4'}
+        body={'Body2'}
+      />
+      <MainFavoriteCard
+        data={{
+          src: 'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
+          alt: '카드',
+          caption: '',
+        }}
+        callout={'2000/00/00'}
       />
       <MainFavoriteCard
         data={{


### PR DESCRIPTION
# 🔢 이슈 번호

- #52 

## ⚙ 작업 사항

- [x] Card 컴포넌트 수정
   - `MainFavoriteCard`의 `Body` 부분이 안보이는 문제 수정
- [x] AppBar 컴포넌트 수정 
    - `AppBar`위에 `MainComponent`의 요소들이 올라가는 문제 수정

## 📃 참고자료

-  

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/44117975/ae8352d3-9df6-473a-a8ea-d827d4d41edc)
