### PR TITLE
BottomNavBar 컴포넌트 수정

### DIFF
--- a/components/BottomNavBar/index.tsx
+++ b/components/BottomNavBar/index.tsx
@@ -1,25 +1,66 @@
+/* eslint-disable react/jsx-key */
 import { BottomComponent, BottomComponentItem } from './style';
 
 import {
   AiOutlineUser,
   AiOutlineTag,
+  AiFillTag,
   AiFillPlusSquare,
+  AiOutlinePlusSquare,
   AiOutlineCrown,
+  AiFillCrown,
   AiOutlineHome,
+  AiFillHome,
 } from 'react-icons/ai';
 
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const icons = [
+  <AiOutlineHome />,
+  <AiOutlineCrown />,
+  <AiOutlinePlusSquare />,
+  <AiOutlineTag />,
+  <AiOutlineUser />,
+];
+
+const activeIcons = [
+  <AiFillHome />,
+  <AiFillCrown />,
+  <AiFillPlusSquare />,
+  <AiFillTag />,
+  <AiFillHome />,
+];
+
+const routes = ['/name', '/ranking', '/plus', '/tag', '/mypage'];
+
+function getActiveIndex(path: string) {
+  for (let i = 0; i < routes.length; i++) {
+    if (path.includes(routes[i])) {
+      return i;
+    }
+  }
+}
 
 export default function BottomNavBar() {
   const router = useRouter();
+  const path = router.asPath;
+  const activeIndex = getActiveIndex(path);
 
-  const bottomNavBarLinkers = [
-    { icon: <AiOutlineHome />, click: () => router.push('/') },
-    { icon: <AiOutlineCrown />, click: () => router.push('/') },
-    { icon: <AiFillPlusSquare />, click: () => router.push('/') },
-    { icon: <AiOutlineTag />, click: () => router.push('/') },
-    { icon: <AiOutlineUser />, click: () => router.push('/') },
-  ];
+  const [bottomNavBarLinkers, setBottomNavBarLinkers] = useState(
+    icons.map((icon, index) => ({
+      icon: index === activeIndex ? activeIcons[index] : icon,
+      click: () => router.push(routes[index]),
+    }))
+  );
+
+  useEffect(() => {
+    const newLinkers = icons.map((icon, index) => ({
+      icon: index === activeIndex ? activeIcons[index] : icon,
+      click: () => router.push(routes[index]),
+    }));
+    setBottomNavBarLinkers(newLinkers);
+  }, [router, activeIndex]);
 
   return (
     <BottomComponent>

--- a/components/BottomNavBar/style.tsx
+++ b/components/BottomNavBar/style.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 
 const BottomComponent = styled.div`
-  height: 56px;
   display: flex;
   justify-content: center;
   width: 100%;
@@ -13,6 +12,7 @@ const BottomComponentItem = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  height: 56px;
   svg {
     width: 24px;
     height: 24px;


### PR DESCRIPTION
# 🔢 이슈 번호

- close #64 

## ⚙ 작업 사항

- [x] 메인 컴포넌트의 길이가 길 경우 하단바의 높이가 작아지는 현상 수정 
- [x] 현재 페이지의 아이콘을 구별이 가능하도록 검정색으로 표기


## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/44117975/afdce82f-4641-418c-aa9e-07207a1cc053)

