### PR TITLE
회원가입 페이지 컴포넌트 수정

### DIFF
--- a/components/Input/Text/style.tsx
+++ b/components/Input/Text/style.tsx
@@ -6,7 +6,9 @@ interface LayoutProps {
 
 const Layout = styled.div<LayoutProps>`
   display: inline-flex;
-  width: ${(props) => (props.size === 'big' ? '100%' : '167px')};
+  width: 100%;
+  max-width: ${(props) => (props.size === 'big' ? '350px' : '167px')};
+
   height: 42px;
   border-bottom: 2px solid ${(props) => props.theme.color.grey_80};
   &:hover {
@@ -27,6 +29,7 @@ const SearchIcon = styled(FlexLayout)`
     height: 18.75px;
   }
 `;
+
 const SearchInput = styled(FlexLayout)`
   flex-grow: 1;
 `;

--- a/components/Input/TrueFalse/style.tsx
+++ b/components/Input/TrueFalse/style.tsx
@@ -4,8 +4,6 @@ const Layout = styled.div`
   display: flex;
   width: 100%;
   height: 42px;
-  border: 1px solid black;
-  border-radius: 2px;
 `;
 
 interface ButtonProps {
@@ -14,8 +12,10 @@ interface ButtonProps {
 
 const LeftButton = styled.button<ButtonProps>`
   background-color: ${(props) => (props.state ? 'black' : 'white')};
+  border-radius: 2px 0 0 2px;
   color: ${(props) => (props.state ? 'white' : 'black')};
   width: 50%;
+  border: 1px solid black;
   transition: 0.3s;
 `;
 const RightButton = styled.button<ButtonProps>`
@@ -23,6 +23,8 @@ const RightButton = styled.button<ButtonProps>`
   color: ${(props) => (props.state ? 'black' : 'white')};
   width: 50%;
   transition: 0.3s;
+  border-radius: 0 2px 2px 0;
+  border: 1px solid black;
 `;
 
 const S = { Layout, LeftButton, RightButton };

--- a/components/SignUp/IdInput/index.tsx
+++ b/components/SignUp/IdInput/index.tsx
@@ -6,6 +6,7 @@ import {
   hasSpecialCharacter,
   isMoreThan12Length,
   isMoreThan2Length,
+  badNickname,
 } from '@/hooks/regex';
 import {
   HELPER_TEXT_KOREAN_INITIAL,
@@ -15,6 +16,7 @@ import {
   HELPER_TEXT_NULL,
   NICKNAME_PLACEHODER,
   HELPER_TEXT_2_LENGTH,
+  HELPER_TEXT_BAD_NICKNAME,
 } from '@/constants/business.constants';
 
 interface InputProps {
@@ -46,6 +48,9 @@ export default function IdInput({ setInput, setCanUseId }: InputProps) {
       setCanUseId(false);
     } else if (isMoreThan2Length(value)) {
       updateHelperText(HELPER_TEXT_2_LENGTH, 2);
+      setCanUseId(false);
+    } else if (badNickname(value)) {
+      updateHelperText(HELPER_TEXT_BAD_NICKNAME, 2);
       setCanUseId(false);
     } else {
       if (중복확인()) {

--- a/constants/business.constants.ts
+++ b/constants/business.constants.ts
@@ -6,3 +6,4 @@ export const HELPER_TEXT_VALID = '사용가능합니다.';
 export const HELPER_TEXT_NULL = '입력해주세요';
 export const NICKNAME_PLACEHODER = '특수문자,초성 단독사용 불가/12자 이내';
 export const HELPER_TEXT_2_LENGTH = '2글자 이상 입력해주세요.';
+export const HELPER_TEXT_BAD_NICKNAME = '욕설을 사용하지 말아주세요.';

--- a/hooks/regex.ts
+++ b/hooks/regex.ts
@@ -11,3 +11,15 @@ export const isMoreThan12Length = (value: string) => value.length > 12;
 
 // 글자수가 2자보다 많아야한다
 export const isMoreThan2Length = (value: string) => value.length < 2;
+
+//욕설을 포함하면 사용 불가
+const 욕설리스트 = ['바보', '멍청이', '이바름'];
+
+export const badNickname = (value: string) => {
+  let flag = true;
+
+  for (let i = 0; i < 욕설리스트.length; i++) {
+    if (value.includes(욕설리스트[i])) flag = false;
+  }
+  return !flag;
+};

--- a/pages/sign-up/index.tsx
+++ b/pages/sign-up/index.tsx
@@ -13,7 +13,6 @@ import { AiOutlineArrowLeft } from 'react-icons/ai';
 interface ComponentWithLayout extends FC {
   Layout?: FC<AppLayoutProps>;
 }
-
 interface Style {
   value: Boolean;
   tag: string;
@@ -164,6 +163,8 @@ const SignUp: ComponentWithLayout = () => {
 };
 
 export default SignUp;
+
+export type { ComponentWithLayout, Style };
 
 SignUp.Layout = ({ children }: AppLayoutProps) => {
   return <>{children}</>;


### PR DESCRIPTION
# 🔢 이슈 번호

- close #73 

## ⚙ 작업 사항

- [x] 기존의 디자인이 390px을 기준으로 디자인이 되어있었는데 뷰포트 width가 390보다 작은 기종들을 위해 반응형으로 변경하였습니다.
- [x] `trueFalse`의  가장자리 border가 매끄럽게 이어지지 않는다는 피드백를 받아 수정하였습니다.  
- [x] '욕설'이 닉네임에 포함될 수 없게 하는 정규식을 만들었습니다. (욕설 리스트 추후에 수정 예정) 

## 📃 참고자료

-

## 📷 스크린샷
