### PR TITLE
OOTD API 수정 및 추가연동

### DIFF
--- a/apis/_api/ootd.ts
+++ b/apis/_api/ootd.ts
@@ -14,6 +14,13 @@ export const postOOTD = async (payload: postOOTDPayload) => {
 
 //ootd 조회
 export const getOOTD = async (id: number) => {
+  const { data } = await fetcher.get(`api/v1/ootd?page=0&size=10&userId=${id}`);
+
+  return data;
+};
+
+//ootd 상세정보 조회
+export const getOOTDDetail = async (id: number) => {
   const { data } = await fetcher.get(`api/v1/ootd/${id}`);
 
   return data;

--- a/apis/_api/ootd.ts
+++ b/apis/_api/ootd.ts
@@ -27,8 +27,8 @@ export const getOOTDDetail = async (id: number) => {
 };
 
 //ootd 전체 수정
-export const putOOTD = async (payload: postOOTDPayload) => {
-  const { data } = await fetcher.put(`api/v1/ootd`, payload);
+export const putOOTD = async (ootdId: number, payload: postOOTDPayload) => {
+  const { data } = await fetcher.put(`api/v1/ootd/${ootdId}`, payload);
 
   return data;
 };
@@ -42,9 +42,10 @@ export const deleteOOTD = async (id: number) => {
 
 //ootd 내용, 공개/비공개 여부 수정
 export const patchOOTDIsPrivate = async (
+  ootdId: number,
   payload: patchOOTDIsPrivatePayload
 ) => {
-  const { data } = await fetcher.patch(`api/v1/ootd`, payload);
+  const { data } = await fetcher.patch(`api/v1/ootd/${ootdId}`, payload);
 
   return data;
 };

--- a/apis/_api/type.ts
+++ b/apis/_api/type.ts
@@ -16,7 +16,6 @@ export interface postOOTDPayload {
 
 export interface patchOOTDIsPrivatePayload {
   isPrivate: Boolean;
-  id: number;
 }
 
 export interface postClothPayload {

--- a/apis/_service/user.service.ts
+++ b/apis/_service/user.service.ts
@@ -28,8 +28,8 @@ export const getOOTDDetail = async (id: number) => {
 };
 
 //ootd 전체 수정
-export const putOOTD = async (params: postOOTDPayload) => {
-  const data = await ootdApi.putOOTD(params);
+export const putOOTD = async (ootdId: number, params: postOOTDPayload) => {
+  const data = await ootdApi.putOOTD(ootdId, params);
 
   return data;
 };
@@ -64,9 +64,10 @@ export const DeleteOOTDComent = async (id: number) => {
 
 //ootd 내용, 공개/비공개 여부 수정
 export const patchOOTDIsPrivate = async (
+  ootdId: number,
   payload: patchOOTDIsPrivatePayload
 ) => {
-  const data = await ootdApi.patchOOTDIsPrivate(payload);
+  const data = await ootdApi.patchOOTDIsPrivate(ootdId, payload);
 
   return data;
 };

--- a/apis/_service/user.service.ts
+++ b/apis/_service/user.service.ts
@@ -20,6 +20,13 @@ export const getOOTD = async (id: number) => {
   return data;
 };
 
+//ootd 상세정보 조회
+export const getOOTDDetail = async (id: number) => {
+  const data = await ootdApi.getOOTDDetail(id);
+
+  return data;
+};
+
 //ootd 전체 수정
 export const putOOTD = async (params: postOOTDPayload) => {
   const data = await ootdApi.putOOTD(params);

--- a/apis/domain/OOTD/OOTDApi.tsx
+++ b/apis/domain/OOTD/OOTDApi.tsx
@@ -46,8 +46,8 @@ export const OOTDApi = () => {
   };
 
   //ootd 전체 수정
-  const putOOTD = async (payload: postOOTDPayload) => {
-    const data = await userService.putOOTD(payload);
+  const putOOTD = async (ootdId: number, payload: postOOTDPayload) => {
+    const data = await userService.putOOTD(ootdId, payload);
     return data;
   };
 
@@ -95,9 +95,12 @@ export const OOTDApi = () => {
     }
   };
   //ootd 내용, 공개/비공개 여부 수정
-  const patchOOTDIsPrivate = async (payload: patchOOTDIsPrivatePayload) => {
+  const patchOOTDIsPrivate = async (
+    ootdId: number,
+    payload: patchOOTDIsPrivatePayload
+  ) => {
     try {
-      const data = await userService.patchOOTDIsPrivate(payload);
+      const data = await userService.patchOOTDIsPrivate(ootdId, payload);
       return data;
     } catch (err) {
       alert('관리자에게 문의하세요');

--- a/apis/domain/OOTD/OOTDApi.tsx
+++ b/apis/domain/OOTD/OOTDApi.tsx
@@ -18,6 +18,17 @@ export const OOTDApi = () => {
     }
   };
 
+  //ootd 상세정보 조회
+  const getOOTDDetail = async (id: number) => {
+    try {
+      const { result } = await userService.getOOTDDetail(id);
+
+      return result;
+    } catch (err) {
+      alert('관리자에게 문의하세요');
+      console.log('에러명', err);
+    }
+  };
   //ootd 게시
   const postOOTD = async (payload: postOOTDPayload) => {
     try {
@@ -185,6 +196,7 @@ export const OOTDApi = () => {
   return {
     postOOTD,
     getOOTD,
+    getOOTDDetail,
     putOOTD,
     deleteOOTD,
     getOOTDComment,

--- a/components/Domain/AddOOTD/TagModal/index.tsx
+++ b/components/Domain/AddOOTD/TagModal/index.tsx
@@ -83,7 +83,7 @@ export type ImageWithTag = {
   ootdImageClothesList?: {
     clothesId: number;
     clothesImage: string;
-    coordinate: { xRate: string; yRate: string };
+    coordinate: { xrate: string; yrate: string };
     deviceSize: { deviceWidth: number; deviceHeight: number };
     caption: string;
     size?: string;
@@ -134,8 +134,8 @@ export default function AddTag({
           brand: ClothInformationSampleData[index].brand,
           name: ClothInformationSampleData[index].name,
           coordinate: {
-            xRate: '0',
-            yRate: '0',
+            xrate: '0',
+            yrate: '0',
           },
           caption: '',
           state: 'light',
@@ -148,8 +148,8 @@ export default function AddTag({
             brand: ClothInformationSampleData[index].brand,
             name: ClothInformationSampleData[index].name,
             coordinate: {
-              xRate: '0',
-              yRate: '0',
+              xrate: '0',
+              yrate: '0',
             },
             caption: '',
             state: 'light',

--- a/components/Domain/MyPage/Closet/ClosetOOTD/index.tsx
+++ b/components/Domain/MyPage/Closet/ClosetOOTD/index.tsx
@@ -19,10 +19,6 @@ export default function ClosetOOTD({ myPageOOTDList }: ClosetOOTDProps) {
     '오래된 순'
   );
 
-  const [myPageOOTD, setMyPageOOTD] = useState<MyPageOOTDType[] | undefined>(
-    myPageOOTDList
-  );
-
   const router = useRouter();
 
   const onClickImageList = (index: number) => {
@@ -45,13 +41,13 @@ export default function ClosetOOTD({ myPageOOTDList }: ClosetOOTDProps) {
         </Caption1>
       </S.OOTDSort>
       <S.OOTDList>
-        {myPageOOTD && (
+        {
           <ImageList
             type="column"
-            data={myPageOOTD}
+            data={myPageOOTDList!}
             onClick={onClickImageList}
           />
-        )}
+        }
       </S.OOTDList>
     </S.Layout>
   );

--- a/components/Domain/MyPage/Closet/index.tsx
+++ b/components/Domain/MyPage/Closet/index.tsx
@@ -2,69 +2,33 @@ import { useFunnel } from '@/hooks/use-funnel';
 import S from './style';
 import ClosetTabbar from './ClosetTabbar';
 import ClosetCloth from './ClosetCloth';
-import ClosetOOTD from './ClosetOOTD';
+import ClosetOOTD, { MyPageOOTDType } from './ClosetOOTD';
+import { useEffect, useState } from 'react';
+import { OOTDApi } from '@/apis/domain/OOTD/OOTDApi';
+import { useRecoilValue } from 'recoil';
+import { userId } from '@/utils/recoil/atom';
 
 export default function Closet() {
   const [Funnel, currentStep, handleStep] = useFunnel(['OOTD', 'Cloth']);
-
-  // const [, getOOTD] = useOOTD();
+  const myId = useRecoilValue(userId);
+  const { getOOTD } = OOTDApi();
   // const [getCloth] = useClogth();
 
-  // const myPageOOTDList = getOOTD({ id: 0 });
   // const myPageClothList = getCloth({ id: 0 });
 
-  const myPageOOTDList = [
-    {
-      ootdId: 0,
-      ootdImage:
-        'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    },
-    {
-      ootdId: 1,
-      ootdImage:
-        'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    },
-    {
-      ootdId: 2,
-      ootdImage:
-        'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    },
-    {
-      ootdId: 3,
-      ootdImage:
-        'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    },
-    {
-      ootdId: 4,
-      ootdImage:
-        'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    },
-    {
-      ootdId: 5,
-      ootdImage:
-        'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    },
-    {
-      ootdId: 5,
-      ootdImage:
-        'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    },
-    {
-      ootdId: 5,
-      ootdImage:
-        'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    },
-    {
-      ootdId: 5,
-      ootdImage:
-        'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    },
-    {
-      ootdId: 5,
-      ootdImage:
-        'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    },
-  ];
+  useEffect(() => {
+    const fetchData = async () => {
+      const { content } = await getOOTD(myId);
+      setMyPageOOTDList(
+        content.map((item: any) => {
+          return { ootdId: item.id, ootdImage: item.image };
+        })
+      );
+    };
+    fetchData();
+  }, []);
+
+  const [myPageOOTDList, setMyPageOOTDList] = useState<MyPageOOTDType[]>([]);
 
   const myPageClothList = [
     {

--- a/components/Domain/OOTD/FixModal/index.tsx
+++ b/components/Domain/OOTD/FixModal/index.tsx
@@ -38,8 +38,7 @@ export default function FixModal({
   };
 
   const onClickIsPrivateButton = async () => {
-    await patchOOTDIsPrivate({
-      id: Number(router.query!.OOTDNumber![0]),
+    await patchOOTDIsPrivate(Number(router.query!.OOTDNumber![0]), {
       isPrivate: !isPrivate,
     });
     setPublicSetting(true);

--- a/components/Posting/index.tsx
+++ b/components/Posting/index.tsx
@@ -70,9 +70,9 @@ export default function Posting({
   const router = useRouter();
 
   useEffect(() => {
-    setHeartState(data.like);
-    setBookMarkState(data.bookmark);
-    setFollowState(data.following);
+    setHeartState(data.isLike);
+    setBookMarkState(data.isBookmark);
+    setFollowState(data.isFollowing);
   }, [data]);
 
   //컴포넌트 크기 계산
@@ -306,7 +306,7 @@ export default function Posting({
           setPublicSetting={setPublicSetting}
           reportModalIsOpen={fixModalIsOpen}
           setReportModalIsOpen={setFixModalIsOpen}
-          isPrivate={data.private}
+          isPrivate={data.isPrivate}
           setGetPostReRender={setGetPostReRender}
           getPostReRender={getPostReRender}
         />

--- a/pages/AddOOTD/ClothTag/index.tsx
+++ b/pages/AddOOTD/ClothTag/index.tsx
@@ -61,8 +61,8 @@ export default function ClothTag({
     updatedElements[ootdIndex].ootdImageClothesList![index] = {
       ...updatedElements[ootdIndex].ootdImageClothesList![index],
       coordinate: {
-        xRate: String(data.lastX),
-        yRate: String(data.lastY),
+        xrate: String(data.lastX),
+        yrate: String(data.lastY),
       },
       deviceSize: {
         deviceHeight: componentHeight,
@@ -108,8 +108,8 @@ export default function ClothTag({
                         bounds=".image"
                         onDrag={(e, data) => onDrag(index, ootdIndex, e, data)}
                         defaultPosition={{
-                          x: Number(element.coordinate.xRate),
-                          y: Number(element.coordinate.yRate),
+                          x: Number(element.coordinate.xrate),
+                          y: Number(element.coordinate.yrate),
                         }}
                       >
                         <div className="sample">

--- a/pages/AddOOTD/WriteOOTD/index.tsx
+++ b/pages/AddOOTD/WriteOOTD/index.tsx
@@ -64,8 +64,8 @@ export default function WriteOOTD({
                     clothesId: tag.clothesId,
                     deviceWidth: tag.deviceSize.deviceWidth,
                     deviceHeight: tag.deviceSize.deviceHeight,
-                    xrate: tag.coordinate.xRate,
-                    yrate: tag.coordinate.yRate,
+                    xrate: tag.coordinate.xrate,
+                    yrate: tag.coordinate.yrate,
                   };
                 })
               : [],

--- a/pages/EditOOTD/[...OOTDNumber].tsx
+++ b/pages/EditOOTD/[...OOTDNumber].tsx
@@ -86,7 +86,10 @@ const EditOOTD: ComponentWithLayout = () => {
         }),
         isPrivate: !isOpen,
       };
-      const editOOTDSuccess = await putOOTD(payload);
+      const editOOTDSuccess = await putOOTD(
+        Number(router.query.OOTDNumber![0]),
+        payload
+      );
 
       //edit ootd 성공 여부에 따른 페이지 이동
       if (editOOTDSuccess) {

--- a/pages/EditOOTD/[...OOTDNumber].tsx
+++ b/pages/EditOOTD/[...OOTDNumber].tsx
@@ -76,10 +76,10 @@ const EditOOTD: ComponentWithLayout = () => {
             clothesTags: item.ootdImageClothesList?.map((items) => {
               return {
                 clothesId: items.clothesId,
-                deviceWidth: items.deviceSize.deviceWidth,
-                deviceHeight: items.deviceSize.deviceHeight,
-                xrate: items.coordinate.xRate,
-                yrate: items.coordinate.yRate,
+                deviceWidth: items.deviceSize?.deviceWidth,
+                deviceHeight: items.deviceSize?.deviceHeight,
+                xrate: items.coordinate?.xrate,
+                yrate: items.coordinate?.yrate,
               };
             }),
           };

--- a/pages/EditOOTD/[...OOTDNumber].tsx
+++ b/pages/EditOOTD/[...OOTDNumber].tsx
@@ -28,12 +28,12 @@ const EditOOTD: ComponentWithLayout = () => {
   const [isOpen, setIsOpen] = useState<Boolean>(false);
   const router = useRouter();
 
-  const { getOOTD, putOOTD } = OOTDApi();
+  const { getOOTDDetail, putOOTD } = OOTDApi();
 
   useEffect(() => {
     const fetchData = async () => {
       if (!router.isReady) return;
-      const result = await getOOTD(Number(router.query.OOTDNumber![0]));
+      const result = await getOOTDDetail(Number(router.query.OOTDNumber![0]));
       setImageAndTag(result.ootdImages);
       setContents(result.contents);
       setSelectedStyle(result.styles);

--- a/pages/OOTD/[...OOTDNumber].tsx
+++ b/pages/OOTD/[...OOTDNumber].tsx
@@ -83,7 +83,7 @@ export interface OOTDType {
 }
 
 const OOTD: ComponentWithLayout = () => {
-  const { getOOTD, postOOTDComment } = OOTDApi();
+  const { getOOTDDetail, postOOTDComment } = OOTDApi();
 
   const router = useRouter();
 
@@ -94,7 +94,7 @@ const OOTD: ComponentWithLayout = () => {
     const fetchData = async () => {
       if (!router.isReady) return;
       try {
-        const result = (await getOOTD(
+        const result = (await getOOTDDetail(
           Number(router.query.OOTDNumber![0])
         )) as OOTDType;
 

--- a/pages/OOTD/[...OOTDNumber].tsx
+++ b/pages/OOTD/[...OOTDNumber].tsx
@@ -34,10 +34,10 @@ export interface OOTDType {
   userImage: string; //유저 프로필 이미지
   userId: number;
   createAt: string; //작성일
-  bookmark: Boolean;
-  like: Boolean;
-  private: Boolean;
-  following: Boolean;
+  isBookmark: Boolean;
+  isLike: Boolean;
+  isPrivate: Boolean;
+  isFollowing: Boolean;
   ootdImages: {
     ootdImage: string; //ootd 이미지
     ootdImageClothesList?: {
@@ -109,7 +109,7 @@ const OOTD: ComponentWithLayout = () => {
         });
       } catch (err) {
         alert('없는 페이지입니다');
-        router.push('/main');
+        // router.push('/main');
       }
     };
     fetchData();


### PR DESCRIPTION
# 🔢 이슈 번호

- close #156 

## ⚙ 작업 사항

- [x] 유저 OOTD 리스트 api 연동 
- [x] 서버 `patch` `put` api의 ootdId를 payload에서 url에 포함시키기로 변경
- [x] ootd 상세 조회 api의 key값들 네이밍 변경 

## 📃 참고자료

-

## 📷 스크린샷
