### PR TITLE
마이페이지 버그 수정

### DIFF
--- a/components/Domain/MyPage/Closet/ClosetOOTD/index.tsx
+++ b/components/Domain/MyPage/Closet/ClosetOOTD/index.tsx
@@ -4,10 +4,9 @@ import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import ImageList from '@/components/ImageList';
 import { useRouter } from 'next/router';
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
-import { useRecoilValue } from 'recoil';
-import { userId } from '@/utils/recoil/atom';
 import { OOTDApi } from '@/apis/domain/OOTD/OOTDApi';
 import Spinner from '@/components/Spinner';
+import useEffectAfterMount from '@/hooks/useEffectAfterMount';
 
 export type MyPageOOTDType = {
   ootdId: number;
@@ -23,8 +22,6 @@ export default function ClosetOOTD() {
     router.push(`/ootd/${index}`);
   };
 
-  const myId = useRecoilValue(userId);
-
   const { getOOTD } = OOTDApi();
 
   const [sortStandard, setSortStandard] = useState<'오래된 순' | '최신순'>(
@@ -32,10 +29,11 @@ export default function ClosetOOTD() {
   );
 
   const fetchDataFunction = async (ootdPage: number, size: number) => {
+    if (!router.isReady) return;
     const data = await getOOTD({
       page: ootdPage,
       size,
-      userId: myId,
+      userId: Number(router.query.UserId![0]),
       sortCriteria: 'createdAt',
       sortDirection: sortStandard === '오래된 순' ? 'ASC' : 'DESC',
     });
@@ -63,7 +61,7 @@ export default function ClosetOOTD() {
     );
   }, [ootdData]);
 
-  useEffect(() => {
+  useEffectAfterMount(() => {
     setMyPageOOTDList([]);
     reset();
   }, [sortStandard]);

--- a/components/Domain/MyPage/Profile/index.tsx
+++ b/components/Domain/MyPage/Profile/index.tsx
@@ -53,14 +53,19 @@ export default function Profile({
         <Body3>{data.description}</Body3>
       </S.Introduce>
       {localUserId === showingId ? (
-        <S.ButtonWrap state={false}>
-          <Button3 onClick={() => router.push(`/edit-mypage`)}>
-            프로필 수정
-          </Button3>
-        </S.ButtonWrap>
+        <Button
+          className="editButton"
+          backgroundColor="grey_95"
+          color="grey_00"
+          size="big"
+          onClick={() => router.push(`/edit-mypage`)}
+          border={false}
+        >
+          <Button3>프로필 수정</Button3>
+        </Button>
       ) : (
         <S.ButtonWrap state={data.isFollow}>
-          {data.isFollow ? (
+          {!data.isFollow ? (
             <Button3 onClick={onClickFollowButton}>팔로우</Button3>
           ) : (
             <Button3 onClick={onClickFollowButton}>팔로잉</Button3>

--- a/components/Domain/MyPage/Profile/style.tsx
+++ b/components/Domain/MyPage/Profile/style.tsx
@@ -10,6 +10,10 @@ const Layout = styled.div`
   .profile {
     padding: 24px 0;
   }
+  .editButton {
+    height: 36px;
+    margin: 32px 0 40px 0;
+  }
   border-bottom: 8px solid ${(props) => props.theme.color.grey_95};
 `;
 const BodyInformation = styled.div`
@@ -22,7 +26,13 @@ const BodyInformation = styled.div`
     margin-bottom: 1px;
   }
 `;
-const Introduce = styled.div``;
+const Introduce = styled.div`
+  p {
+    max-width: 100%;
+    overflow-x: hidden;
+    word-wrap: break-word;
+  }
+`;
 
 interface ButtonProps {
   state: Boolean;

--- a/hooks/useEffectAfterMount.tsx
+++ b/hooks/useEffectAfterMount.tsx
@@ -1,0 +1,16 @@
+import { useRef, EffectCallback, DependencyList, useEffect } from 'react';
+
+export default function useEffectAfterMount(
+  effect: EffectCallback,
+  dependencies?: DependencyList
+) {
+  const initialRender = useRef(true);
+
+  useEffect(() => {
+    if (initialRender.current) {
+      initialRender.current = false;
+    } else {
+      effect();
+    }
+  }, dependencies);
+}

--- a/pages/mypage/[...UserId].tsx
+++ b/pages/mypage/[...UserId].tsx
@@ -107,7 +107,7 @@ export default function MyPage() {
             localUserId === showingId ? (
               <AiOutlineSetting
                 className="setting"
-                onClick={() => router.push('/Setting')}
+                onClick={() => router.push('/settings')}
               />
             ) : (
               <AiOutlineEllipsis onClick={() => setBlockOpen(true)} />


### PR DESCRIPTION
# 🔢 이슈 번호

- close #202

## ⚙ 작업 사항


- 전역 userId에서 query userId로 변경
- 프로필 수정 버튼 색상 변경
- 설정 router 경로 변경
- description 최대 길이 설정


## 📃 참고자료
이번 이슈에서 `useEffectAfterMount` 훅을 만들었습니다.
해당 훅은 **useEffect** 실행 시 최초 한번 실행을 막아주는 훅 입니다.
기존 **useEffect**처럼 사용하시면 됩니다.
```ts
  useEffectAfterMount(() => {
    setMyPageOOTDList([]);
    reset();
  }, [sortStandard]);
```


## 📷 스크린샷

![image](https://github.com/ootd-zip/client/assets/158991486/2a46a7f5-556e-45e0-ab39-14d4e24e1bd3)
![image](https://github.com/ootd-zip/client/assets/158991486/baa66b4e-bb2c-4921-aaaa-a4a2fbfde499)