### PR TITLE
ootd 상세페이지 수정

### DIFF
--- a/apis/domain/OOTD/OOTDApi.tsx
+++ b/apis/domain/OOTD/OOTDApi.tsx
@@ -56,8 +56,9 @@ export const OOTDApi = () => {
   //ootd 삭제
   const deleteOOTD = async (id: number) => {
     try {
-      const data = await userService.deleteOOTD(id);
-      return data;
+      const { statusCode } = await userService.deleteOOTD(id);
+      if (statusCode === 200) return true;
+      return false;
     } catch (err) {
       alert('관리자에게 문의하세요');
       console.log('에러명', err);

--- a/components/ActionSheet/style.tsx
+++ b/components/ActionSheet/style.tsx
@@ -27,7 +27,8 @@ const ButtonWrap = styled.div<ButtonWrapType>`
   gap: 8px;
   flex: 1 0 0;
   border-bottom: 1px solid ${(props) => props.theme.color.grey_95};
-  color: ${(props) => props.name === '삭제' && `${props.theme.color.error}`};
+  color: ${(props) =>
+    props.name.includes('삭제') && `${props.theme.color.error}`};
 `;
 
 const S = {

--- a/components/ClothInformation/TagInformation/index.tsx
+++ b/components/ClothInformation/TagInformation/index.tsx
@@ -13,9 +13,10 @@ export default function TagInformation({
   state,
   className,
   type,
+  onClick,
 }: ClothInformationProps) {
   return (
-    <S.Layout className={className} state={state!}>
+    <S.Layout onClick={onClick} className={className} state={state!}>
       <S.ItemImage>
         <Image width={32} height={32} src={clothImage} alt="아이템" />
       </S.ItemImage>

--- a/components/Domain/OOTD/FixModal/index.tsx
+++ b/components/Domain/OOTD/FixModal/index.tsx
@@ -1,10 +1,10 @@
-import Modal from '@/components/Modal';
 import S from './style';
 import { Body3, Button1, Title1 } from '@/components/UI';
 import { Dispatch, SetStateAction, useState } from 'react';
 import Alert from '@/components/Alert';
 import { useRouter } from 'next/router';
 import { OOTDApi } from '@/apis/domain/OOTD/OOTDApi';
+import ActionSheet from '@/components/ActionSheet';
 
 interface ReportModalProps {
   reportModalIsOpen: Boolean;
@@ -45,27 +45,27 @@ export default function FixModal({
     setDeleteAlertIsOpen(false);
     setToastOpen(true);
   };
+
+  const buttons = [
+    {
+      name: (!isPrivate ? '비' : '') + `공개로 설정`,
+      buttonClick: onClickIsPrivateButton,
+      color: 'error',
+    },
+    {
+      name: 'ootd 수정',
+      buttonClick: onClickIsPrivateButton,
+    },
+    {
+      name: 'ootd 삭제',
+      buttonClick: onClickIsPrivateButton,
+    },
+  ];
   return (
     <>
       <S.Background onClick={() => ''} isOpen={deleteAlertIsOpen} />
       <S.Layout onClick={onClickReportButton}>
-        <Modal className="modal" isOpen={reportModalIsOpen} height="30">
-          <S.Span onClick={onClickIsPrivateButton}>
-            <Button1 className="report">
-              {!isPrivate && <>비</>}공개로 설정
-            </Button1>
-          </S.Span>
-          <S.Span
-            onClick={() =>
-              router.push(`/edit-ootd/${Number(router.query!.OOTDNumber![0])}`)
-            }
-          >
-            <Button1 className="report">ootd 수정</Button1>
-          </S.Span>
-          <S.Span onClick={() => setDeleteAlertIsOpen(true)}>
-            <Button1 className="report delete">ootd 삭제</Button1>
-          </S.Span>
-        </Modal>
+        {reportModalIsOpen && <ActionSheet buttons={buttons} />}
         {deleteAlertIsOpen && (
           <Alert
             headline={<Title1>게시글을 삭제하시겠습니까?</Title1>}

--- a/components/Domain/OOTD/FixModal/index.tsx
+++ b/components/Domain/OOTD/FixModal/index.tsx
@@ -5,6 +5,8 @@ import Alert from '@/components/Alert';
 import { useRouter } from 'next/router';
 import { OOTDApi } from '@/apis/domain/OOTD/OOTDApi';
 import ActionSheet from '@/components/ActionSheet';
+import { useRecoilValue } from 'recoil';
+import { userId } from '@/utils/recoil/atom';
 
 interface ReportModalProps {
   reportModalIsOpen: Boolean;
@@ -28,13 +30,16 @@ export default function FixModal({
   };
 
   const router = useRouter();
+  const myId = useRecoilValue(userId);
+
   const { deleteOOTD, patchOOTDIsPrivate } = OOTDApi();
 
   const [deleteAlertIsOpen, setDeleteAlertIsOpen] = useState<Boolean>(false);
 
   const onClickYesButton = async () => {
-    await deleteOOTD(Number(router.query!.OOTDNumber![0]));
+    const result = await deleteOOTD(Number(router.query!.OOTDNumber![0]));
     setDeleteAlertIsOpen(false);
+    if (result) router.push(`/mypage/${myId}`);
   };
 
   const onClickIsPrivateButton = async () => {
@@ -46,6 +51,10 @@ export default function FixModal({
     setToastOpen(true);
   };
 
+  const onClickDeleteButton = async () => {
+    setDeleteAlertIsOpen(true);
+  };
+
   const buttons = [
     {
       name: (!isPrivate ? '비' : '') + `공개로 설정`,
@@ -54,11 +63,12 @@ export default function FixModal({
     },
     {
       name: 'ootd 수정',
-      buttonClick: onClickIsPrivateButton,
+      buttonClick: () =>
+        router.push(`/edit-ootd/${Number(router.query.OOTDNumber![0])}`),
     },
     {
       name: 'ootd 삭제',
-      buttonClick: onClickIsPrivateButton,
+      buttonClick: onClickDeleteButton,
     },
   ];
   return (

--- a/components/Domain/OOTD/SimilarOOTD/index.tsx
+++ b/components/Domain/OOTD/SimilarOOTD/index.tsx
@@ -28,7 +28,7 @@ export default function SimilarOOTD() {
   }, [router.isReady, router.query.OOTDNumber]);
 
   const onClickSimilarOOTDImage = (ootdId: number) => {
-    router.push(`/OOTD/${ootdId}`);
+    router.push(`/ootd/${ootdId}`);
   };
 
   return (

--- a/components/Domain/OOTD/SimilarOOTD/index.tsx
+++ b/components/Domain/OOTD/SimilarOOTD/index.tsx
@@ -43,7 +43,7 @@ export default function SimilarOOTD() {
         {data && (
           <ImageList
             onClick={onClickSimilarOOTDImage}
-            type="row"
+            type="column"
             data={data.map((item) => {
               return { ootdId: item.id, ootdImage: item.image };
             })}

--- a/components/Domain/OOTD/UserCloth/index.tsx
+++ b/components/Domain/OOTD/UserCloth/index.tsx
@@ -52,7 +52,9 @@ export default function UserCloth({ userName, userId }: UserClothProps) {
     <S.Layout>
       <S.Title>
         <Title1>{userName}님의 옷장</Title1>
-        <Button3 onClick={() => router.push(`/mypage`)}>더보기</Button3>
+        <Button3 onClick={() => router.push(`/mypage/${userId}`)}>
+          더보기
+        </Button3>
       </S.Title>
       <S.Cloth>
         <Carousel slidesToShow={1.1} infinite={false} dots={false}>

--- a/components/Domain/OOTD/UserOtherOOTD/index.tsx
+++ b/components/Domain/OOTD/UserOtherOOTD/index.tsx
@@ -47,6 +47,7 @@ export default function UserOtherOOTD({ userId, userName }: UserOOTDProps) {
               {data.map((item) => {
                 return (
                   <img
+                    onClick={() => router.push(`/ootd/${item.id}`)}
                     key={item.id}
                     src={item.image}
                     alt="이 유저의 다른 ootd"

--- a/components/Domain/OOTD/UserOtherOOTD/index.tsx
+++ b/components/Domain/OOTD/UserOtherOOTD/index.tsx
@@ -2,10 +2,10 @@
 import { Title1 } from '@/components/UI';
 import S from './style';
 import { useRouter } from 'next/router';
-import ImageList from '@/components/ImageList';
 import { useState } from 'react';
 import { useEffect } from 'react';
 import { OOTDApi } from '@/apis/domain/OOTD/OOTDApi';
+import Carousel from '@/components/Carousel';
 
 interface UserOOTDProps {
   userId?: number;
@@ -37,20 +37,26 @@ export default function UserOtherOOTD({ userId, userName }: UserOOTDProps) {
 
   return (
     <S.Layout>
-      <S.Title>
-        <Title1>{userName}님의 다른 OOTD</Title1>
-      </S.Title>
-      <S.OOTD>
-        {data && (
-          <ImageList
-            onClick={(ootdId: number) => router.push(`/ootd/${ootdId}`)}
-            type="row"
-            data={data.map((item) => {
-              return { ootdId: item.id, ootdImage: item.image };
-            })}
-          />
-        )}
-      </S.OOTD>
+      {data && (
+        <>
+          <S.Title>
+            <Title1>{userName}님의 다른 OOTD</Title1>
+          </S.Title>
+          <S.OOTD>
+            <Carousel infinite={false} slidesToShow={2.1} dots={false}>
+              {data.map((item) => {
+                return (
+                  <img
+                    key={item.id}
+                    src={item.image}
+                    alt="이 유저의 다른 ootd"
+                  />
+                );
+              })}
+            </Carousel>
+          </S.OOTD>
+        </>
+      )}
     </S.Layout>
   );
 }

--- a/components/Domain/OOTD/UserOtherOOTD/style.tsx
+++ b/components/Domain/OOTD/UserOtherOOTD/style.tsx
@@ -1,22 +1,22 @@
 import styled from 'styled-components';
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
 
 const Layout = styled.div`
-  padding: 0 20px;
+  padding: 0 0 0 20px;
 `;
 const Title = styled.div`
   padding: 21px 0;
 `;
 const OOTD = styled.div`
-  display: flex;
-  gap: 4px;
-  width: 100%;
-  overflow-x: scroll;
-  padding-bottom: 48px;
   img {
-    width: 167px;
+    width: 167 !important;
     height: 167px;
     object-fit: cover;
-    flex-shrink: 0;
+    padding-right: 4px;
+  }
+  .slick-track {
+    margin: 0;
   }
 `;
 

--- a/components/Domain/OOTD/UserOtherOOTD/style.tsx
+++ b/components/Domain/OOTD/UserOtherOOTD/style.tsx
@@ -3,7 +3,7 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 
 const Layout = styled.div`
-  padding: 0 0 0 20px;
+  padding: 0 0 48px 20px;
 `;
 const Title = styled.div`
   padding: 21px 0;

--- a/components/Posting/index.tsx
+++ b/components/Posting/index.tsx
@@ -236,6 +236,9 @@ export default function Posting({
                           )}
                         >
                           <TagInformation
+                            onClick={() =>
+                              router.push(`/cloth/${items.clothesId}`)
+                            }
                             clothId={items.clothesId}
                             clothImage={items.clothesImage}
                             caption={'tag'}
@@ -263,11 +266,11 @@ export default function Posting({
             onClick={() => commentRef.current.focus()}
             alt="댓글"
           />
-          <ShareOutlined
+          {/* <ShareOutlined
             className="share"
             onClick={onClickShareButton}
             alt="공유하기"
-          />
+          /> */}
           {bookMarkState ? (
             <BookmarkFilled
               className="bookmark"

--- a/components/Posting/index.tsx
+++ b/components/Posting/index.tsx
@@ -184,12 +184,25 @@ export default function Posting({
       <S.Layout>
         <S.PostingTop>
           {data.userName === 'string' ? (
-            <img src={data.userImage} className="userImage" alt="유저 이미지" />
+            <img
+              onClick={() => router.push(`/mypage/${data.userId}`)}
+              src={data.userImage}
+              className="userImage"
+              alt="유저 이미지"
+            />
           ) : (
-            <Avatar className="avatar" />
+            <Avatar
+              onClick={() => router.push(`/mypage/${data.userId}`)}
+              className="avatar"
+            />
           )}
 
-          <Body3 className="userName">{data.userName}</Body3>
+          <Body3
+            onClick={() => router.push(`/mypage/${data.userId}`)}
+            className="userName"
+          >
+            {data.userName}
+          </Body3>
           {!myPost && !followState && (
             <Button3 onClick={onClickFollowButton} className="unfollow">
               팔로우

--- a/pages/ootd/[...OOTDNumber].tsx
+++ b/pages/ootd/[...OOTDNumber].tsx
@@ -100,7 +100,7 @@ const OOTD: ComponentWithLayout = () => {
 
         setData({
           ...result,
-          createAt: new Date(result.createAt).toLocaleDateString(),
+          createAt: new Date(result.createAt).toLocaleDateString('ko-KR'),
         });
         setComment({
           ootdId: Number(router.query.OOTDNumber![0]),


### PR DESCRIPTION
# 🔢 이슈 번호

- close #209 

## ⚙ 작업 사항

- 공유 버튼 임시 숨기기
- 태그된 옷 클릭 시 옷으로 이동
- 작성날짜 kr로 변경
- `비슷한 ootd` 레이아웃 변경
   - 가로 -> 세로  
- **다른 ootd** `carousel` 추가
- 수정 모달 `ActionSheet`로 변경

## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/eb92b0cc-84c4-4321-89f8-1a3f63709edb)
![image](https://github.com/ootd-zip/client/assets/158991486/81968d3c-fa77-4b98-9c65-ec75e1818f60)
