### PR TITLE
Alert 재구현

### DIFF
--- a/components/Alert/index.tsx
+++ b/components/Alert/index.tsx
@@ -33,7 +33,7 @@ export default function Alert({
         {yes && no && (
           <S.AlertButton yesColor={yesColor} noColor={noColor}>
             <button onClick={onClickNoButton} className="no">
-              <Button1>{no}</Button1>
+              <Button1 state="thin">{no}</Button1>
             </button>
             <button onClick={onClickYesButton} className="yes">
               <Button1>{yes}</Button1>

--- a/components/Alert/index.tsx
+++ b/components/Alert/index.tsx
@@ -1,13 +1,16 @@
 import S from './style';
-import { Button2, Button3 } from '../UI';
+import { Body3, Button1, Button2, Button3, Title1 } from '../UI';
+import { ReactNode } from 'react';
 
 interface AlertProps {
   onClickYesButton: () => void;
   onClickNoButton: () => void;
-  headline: React.ReactNode;
-  body: React.ReactNode;
+  headline: string;
+  body: ReactNode;
   yes?: string;
+  yesColor?: string;
   no?: string;
+  noColor?: string;
 }
 
 export default function Alert({
@@ -16,20 +19,24 @@ export default function Alert({
   headline,
   body,
   yes,
+  yesColor,
   no,
+  noColor,
 }: AlertProps) {
   return (
     <S.Layout>
       <S.AlertPrompt>
-        <S.AlertHeadline>{headline}</S.AlertHeadline>
+        <S.AlertHeadline>
+          <Title1>{headline}</Title1>
+        </S.AlertHeadline>
         <S.AlertBody>{body}</S.AlertBody>
         {yes && no && (
-          <S.AlertButton>
+          <S.AlertButton yesColor={yesColor} noColor={noColor}>
             <button onClick={onClickNoButton} className="no">
-              <Button2>{no}</Button2>
+              <Button1>{no}</Button1>
             </button>
             <button onClick={onClickYesButton} className="yes">
-              <Button3>{yes}</Button3>
+              <Button1>{yes}</Button1>
             </button>
           </S.AlertButton>
         )}

--- a/components/Alert/style.tsx
+++ b/components/Alert/style.tsx
@@ -9,41 +9,49 @@ const Layout = styled.div`
   left: 50%;
   z-index: 999;
   transform: translate(-50%, -50%);
-  border-radius: 14px;
-  background: #e5e5e5;
+  background: ${(props) => props.theme.color.grey_100};
   backdrop-filter: blur(40px);
   text-align: center;
+  border-top: 2px solid black;
+  border-bottom: 2px solid black;
 `;
 
 const AlertPrompt = styled.div``;
 
 const AlertHeadline = styled.div`
-  padding-top: 19px;
+  padding-top: 35px;
 `;
 
 const AlertBody = styled.div`
   width: 238px;
-  padding: 0px 16px 15px 16px;
+  padding: 0px 16px 35px 16px;
   display: flex;
   flex-direction: column;
-  white-space: nowrap;
   box-sizing: content-box;
+  overflow-wrap: break-word;
+  word-break: keep-all;
   p {
     flex-shrink: 0;
   }
 `;
-const AlertButton = styled.div`
+
+interface AlertButtonProps {
+  yesColor?: string;
+  noColor?: string;
+}
+
+const AlertButton = styled.div<AlertButtonProps>`
   button {
     width: 50%;
-    border-radius: var(--Number, 0px);
-    border-top: 0.333px solid rgba(60, 60, 67, 0.36);
-    padding: 11px 41px;
-    color: #007aff;
+    border-top: 0.5px solid ${(props) => props.theme.color.grey_95};
+    padding: 13px 0;
+    color: ${(props) => props.theme.color.preferred};
     &.yes p {
+      color: ${(props) => props.yesColor && props.theme.color[props.yesColor]};
       font-weight: 600 !important;
     }
     &.no p {
-      color: red;
+      color: ${(props) => props.noColor && props.theme.color[props.noColor]};
     }
   }
 `;

--- a/components/DetailCloth/DeleteAlert/index.tsx
+++ b/components/DetailCloth/DeleteAlert/index.tsx
@@ -14,15 +14,15 @@ export default function DeleteAlert({
     <Alert
       onClickYesButton={onClickYesButton}
       onClickNoButton={onClickNoButton}
-      headline={<Title1>옷장에서 옷을 삭제하시겠습니까?</Title1>}
+      headline="옷장에서 옷을 삭제하시겠습니까"
       body={
-        <>
-          <Body3>확인을 누르시면 옷장에서 옷이 삭제되며 다시</Body3>
-          <Body3>복구할 수 없습니다.</Body3>
-        </>
+        <Body3>
+          확인을 누르시면 옷장에서 옷이 삭제되며 다시 복구할 수 없습니다.
+        </Body3>
       }
-      yes={'할래'}
-      no={'안할래'}
+      yes={'취소'}
+      yesColor="error"
+      no={'확인'}
     />
   );
 }

--- a/components/Domain/AddCloth/AddClothAlert/index.tsx
+++ b/components/Domain/AddCloth/AddClothAlert/index.tsx
@@ -14,7 +14,7 @@ export default function AddClothAlert({
     <Alert
       onClickYesButton={onClickYesButton}
       onClickNoButton={onClickNoButton}
-      headline={<Title1>추가정보...입력하지 않을래?</Title1>}
+      headline="추가정보...입력하지 않을래?"
       body={
         <>
           <Body3>추가정보...입력하면 좋을텐데...</Body3>

--- a/components/Domain/Bookmark/BookmarkAlert/index.tsx
+++ b/components/Domain/Bookmark/BookmarkAlert/index.tsx
@@ -14,13 +14,14 @@ export default function BookmarkAlert({
     <Alert
       onClickYesButton={onClickYesButton}
       onClickNoButton={onClickNoButton}
-      headline={<Title1>북마크에서 삭제하시겠습니까?</Title1>}
+      headline="북마크에서 삭제하시겠습니까?"
       body={
         <>
-          <Body3>삭제냐 안 삭제냐 그것이 문제로다</Body3>
+          <Body3>삭제를 누르면 해당 콘텐츠의 북마크가 해제됩니다.</Body3>
         </>
       }
       yes={'취소'}
+      yesColor="error"
       no={'삭제'}
     />
   );

--- a/components/Domain/FollowList/FollowAlert/index.tsx
+++ b/components/Domain/FollowList/FollowAlert/index.tsx
@@ -14,14 +14,15 @@ export default function FollowAlert({
     <Alert
       onClickYesButton={onClickYesButton}
       onClickNoButton={onClickNoButton}
-      headline={<Title1>팔로워에서 삭제하시겠습니까?</Title1>}
+      headline="팔로워에서 삭제하시겠습니까?"
       body={
         <>
-          <Body3>Username님은 회원님의 팔로워 리스트에서</Body3>
-          <Body3>삭제된 것을 알 수 없습니다.</Body3>
+          <Body3>Username님은 회원님의 팔로워 리스트에</Body3>
+          <Body3>서 삭제된 것을 알 수 없습니다.</Body3>
         </>
       }
       yes={'삭제'}
+      yesColor="error"
       no={'닫기'}
     />
   );

--- a/components/Domain/MyPage/BlockAlert/index.tsx
+++ b/components/Domain/MyPage/BlockAlert/index.tsx
@@ -16,16 +16,17 @@ export default function BlockAlert({
     <Alert
       onClickYesButton={onClickYesButton}
       onClickNoButton={onClickNoButton}
-      headline={<Title1>{blockUserName}님을 차단하시겠습니까?</Title1>}
+      headline={`${blockUserName}님을 차단하시겠습니까?`}
       body={
         <>
-          <Body3>해당 유저의 프로필 및 콘텐츠가 표시되지 않</Body3>
-          <Body3>습니다. 부적절한 사용자의 경우 신고 기능을</Body3>
-          <Body3>이용해주시기 바랍니다.</Body3>
+          <Body3>해당 유저의 프로필 및 콘텐츠가 표시되지</Body3>
+          <Body3>않습니다. 부적절한 사용자의 경우 신고 기</Body3>
+          <Body3>능을이용해주시기 바랍니다.</Body3>
         </>
       }
       yes={'차단'}
       no={'닫기'}
+      noColor="error"
     />
   );
 }

--- a/components/Domain/OOTD/FixModal/index.tsx
+++ b/components/Domain/OOTD/FixModal/index.tsx
@@ -78,10 +78,11 @@ export default function FixModal({
         {reportModalIsOpen && <ActionSheet buttons={buttons} />}
         {deleteAlertIsOpen && (
           <Alert
-            headline={<Title1>게시글을 삭제하시겠습니까?</Title1>}
-            body={<Body3>삭제된 게시글은 다시 복구할 수 없습니다.</Body3>}
-            yes="확인"
+            headline="게시글을 삭제하시겠습니까?"
+            body={<Body3>삭제된 게시글은 다시 복구할 수 없습니다. </Body3>}
+            yes="삭제"
             no="취소"
+            yesColor="error"
             onClickYesButton={onClickYesButton}
             onClickNoButton={() => setDeleteAlertIsOpen(false)}
           />

--- a/components/Gallery/index.tsx
+++ b/components/Gallery/index.tsx
@@ -187,21 +187,21 @@ const Gallery = ({
       </NextButton>
       {isOpenStoredImageAlert && (
         <Alert
-          headline={<Title1>작성 중이던 게시글이 있습니다.</Title1>}
+          headline="작성 중이던 게시글이 있습니다."
           body={
             <>
               <Body3>
                 이어서 작성하시겠습니까?
                 <br />
-                아니오를 누를 경우 임시저장본은 삭제되며 새<br />
-                로운 게시글을 작성할 수 있습니다.
+                아니오를 누를 경우 임시저장본은 삭제되며 새로운 게시글을 작성할
+                수 있습니다.
               </Body3>
             </>
           }
           onClickYesButton={getStoredImage}
           onClickNoButton={dontGetStoredImage}
-          yes="네"
-          no="아니오"
+          yes="취소"
+          no="확인"
         />
       )}
     </S.Layout>

--- a/components/Gallery/index.tsx
+++ b/components/Gallery/index.tsx
@@ -200,8 +200,8 @@ const Gallery = ({
           }
           onClickYesButton={getStoredImage}
           onClickNoButton={dontGetStoredImage}
-          yes="취소"
-          no="확인"
+          no="취소"
+          yes="확인"
         />
       )}
     </S.Layout>

--- a/components/Setting/BlockAlert/index.tsx
+++ b/components/Setting/BlockAlert/index.tsx
@@ -14,7 +14,7 @@ export default function BlockAlert({
     <Alert
       onClickYesButton={onClickYesButton}
       onClickNoButton={onClickNoButton}
-      headline={<Title1>차단이 해제되었습니다.</Title1>}
+      headline="차단이 해제되었습니다."
       body={
         <>
           <Body3>팔로우하시겠습니까?</Body3>

--- a/components/Setting/WithdrawAlert/index.tsx
+++ b/components/Setting/WithdrawAlert/index.tsx
@@ -14,14 +14,15 @@ export default function WithdrawAlert({
     <Alert
       onClickYesButton={onClickYesButton}
       onClickNoButton={onClickNoButton}
-      headline={<Title1>정말 탈퇴하시겠습니까?</Title1>}
+      headline="정말 탈퇴하시겠습니까?"
       body={
         <>
           <Body3>탈퇴 버튼을 누르면 탈퇴가 완료됩니다.</Body3>
         </>
       }
-      yes={'취소'}
-      no={'탈퇴'}
+      no={'취소'}
+      yes={'탈퇴'}
+      yesColor="error"
     />
   );
 }

--- a/components/UI/TypoGraphy/Button1.tsx
+++ b/components/UI/TypoGraphy/Button1.tsx
@@ -1,10 +1,19 @@
 import styled from 'styled-components';
 
-const Button1 = styled.p`
+interface Button1State {
+  state?: 'thin';
+}
+
+const Button1 = styled.p<Button1State>`
   font-weight: ${({ theme }) => theme.weight.semibold}; //600
   font-size: ${({ theme }) => theme.fontSize.lg}; //18px
   line-height: ${({ theme }) => theme.lineHeight.lg}; //24px
   letter-spacing: ${({ theme }) => theme.spacing.default}; //0%
+  ${(props) =>
+    props.state === 'thin' &&
+    `
+    font-weight: ${props.theme.weight.regular};
+  `}
 `;
 
 export default Button1;

--- a/components/UI/TypoGraphy/Button3.tsx
+++ b/components/UI/TypoGraphy/Button3.tsx
@@ -12,7 +12,7 @@ const Button3 = styled.p<Button3State>`
   ${(props) =>
     props.state === 'emphasis' &&
     `
-    font-wiehgt: ${props.theme.weight.semibold};
+    font-weight: ${props.theme.weight.semibold};
   `}
 `;
 


### PR DESCRIPTION
# 🔢 이슈 번호

- close #212 

## ⚙ 작업 사항

- [x] 디자인 시안 변경으로 인한 `Alert` 컴포넌트 재구현  
- [x] Button1 폰트의 **thin**상태 추가

## 📃 참고자료

### `Alert` 관련 디자이너와 회의
현재 디자인 시안을 보면 `Alert 창의 목적을 가진 버튼`이 **왼쪽**에 있는 경우가 있는데
디자이너와 상의해 앞으로 `Alert 창의 목적을 가진 버튼`이 **무조건 오른쪽**으로 오기로 했습니다.

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/e83ae7a4-3a2b-4840-b2bb-b01fc5326dcb)
