### PR TITLE
내 정보 수정 페이지 css 세부 사항 수정

### DIFF
--- a/components/Domain/MyPage/Edit/EditMyInfo/index.tsx
+++ b/components/Domain/MyPage/Edit/EditMyInfo/index.tsx
@@ -79,6 +79,7 @@ export default function EditMyInfo({
         <S.Category>
           <Body3>소개</Body3>
           <Input.Text
+            state={true}
             defaultValue={introduction}
             size="big"
             line="outline"

--- a/components/Domain/MyPage/Edit/EditMyInfo/style.tsx
+++ b/components/Domain/MyPage/Edit/EditMyInfo/style.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 const Layout = styled.div`
   width: 100%;
   display: inline-flex;
-  padding: 0px 20px;
   flex-direction: column;
   align-items: flex-start;
   gap: 24px;
@@ -25,7 +24,6 @@ const BodyInfo = styled.div`
 
 const OpenStatus = styled.div`
   display: inline-flex;
-  padding: 0px 20px;
   flex-direction: column;
   align-items: flex-start;
   margin-top: 16px;

--- a/components/Domain/MyPage/Edit/EditProfile/index.tsx
+++ b/components/Domain/MyPage/Edit/EditProfile/index.tsx
@@ -21,10 +21,6 @@ export default function EditProfile({
     onClickImage();
   };
 
-  const onClickBackground = () => {
-    if (openActionSheet) setOpenActionSheet(false);
-  };
-
   return (
     <>
       <S.Layout>

--- a/components/Domain/MyPage/Edit/index.tsx
+++ b/components/Domain/MyPage/Edit/index.tsx
@@ -11,8 +11,19 @@ import {
 import { UserApi } from '@/apis/domain/User/UserApi';
 import { Button3 } from '@/components/UI';
 import { useRouter } from 'next/router';
+import Button from '@/components/Button';
+import { useRecoilValue } from 'recoil';
+import { userId } from '@/utils/recoil/atom';
 
-export default function Closet() {
+interface ActionSheetProps {
+  openActionSheet: Boolean;
+  setOpenActionSheet: Dispatch<SetStateAction<Boolean>>;
+}
+
+export default function Edit({
+  openActionSheet,
+  setOpenActionSheet,
+}: ActionSheetProps) {
   const router = useRouter();
 
   const [profileImage, setProfileImage] = useState<string>(
@@ -23,8 +34,6 @@ export default function Closet() {
   const [height, setHeight] = useState<string>('160');
   const [weight, setWeight] = useState<string>('40');
   const [open, setOpen] = useState<Boolean>(true);
-
-  const [openActionSheet, setOpenActionSheet] = useState<Boolean>(false);
 
   const { getProfile, patchProfile } = UserApi();
 
@@ -57,6 +66,8 @@ export default function Closet() {
     { name: '앨범에서 선택', buttonClick: choosePicture },
     { name: '기본 이미지로 변경', buttonClick: deleteImage },
   ];
+
+  const myId = useRecoilValue(userId);
 
   useEffect(() => {
     const ferchData = async () => {
@@ -105,7 +116,7 @@ export default function Closet() {
 
       if (result) {
         router.push({
-          pathname: '/mypage',
+          pathname: `/mypage/${myId}`,
           query: { state: 'editSuccess' },
         });
       } else {
@@ -116,10 +127,6 @@ export default function Closet() {
 
   return (
     <>
-      <S.Background
-        isOpen={openActionSheet}
-        onClick={() => setOpenActionSheet(false)}
-      />
       <S.Layout>
         <EditProfile
           imageURL={profileImage}
@@ -140,9 +147,16 @@ export default function Closet() {
           possible={possible}
           setPossible={setPossible}
         />
-        <S.ButtonWrap onClick={onClickNextButton} state={possible}>
+        <Button
+          className="editMyPageButton"
+          backgroundColor={possible ? 'grey_00' : 'grey_90'}
+          color="grey_100"
+          size="big"
+          onClick={onClickNextButton}
+          border={false}
+        >
           <Button3>수정 완료</Button3>
-        </S.ButtonWrap>
+        </Button>
       </S.Layout>
 
       {openActionSheet && <ActionSheet buttons={buttons} />}

--- a/components/Domain/MyPage/Edit/style.tsx
+++ b/components/Domain/MyPage/Edit/style.tsx
@@ -2,37 +2,9 @@ import styled from 'styled-components';
 
 const Layout = styled.div`
   height: calc(100vh - 100px);
-`;
-
-interface BackgroundProps {
-  isOpen: Boolean;
-}
-
-const Background = styled.div<BackgroundProps>`
-  background-color: ${(props) => props.theme.color.grey_00};
-  display: ${(props) => (props.isOpen ? 'block' : 'none')};
-  opacity: 0.3;
-  z-index: 2;
-  width: 100vw;
-  height: calc(100vh - 48px);
-  position: absolute;
-`;
-
-interface ButtonProps {
-  state: Boolean;
-}
-
-const ButtonWrap = styled.div<ButtonProps>`
   margin: 0px 20px;
-  width: calc(100% - 40px);
-  margin-top: 88px;
-  background-color: ${(props) =>
-    props.state ? props.theme.color.grey_00 : props.theme.color.grey_90};
-  padding: 14px 0px;
-  color: ${(props) => props.theme.color.grey_100};
-  text-align: center;
 `;
 
-const S = { Layout, Background, ButtonWrap };
+const S = { Layout };
 
 export default S;

--- a/components/Input/Text/style.tsx
+++ b/components/Input/Text/style.tsx
@@ -34,6 +34,7 @@ const Layout = styled.div<LayoutProps>`
   ${(props) =>
     props.line === 'outline' &&
     ` 
+    padding-right:8px;
   border: 1px solid ${props.theme.color.grey_80};
   &:hover {
     border: 1px solid ${props.theme.color.grey_00};

--- a/pageStyle/edit-mypage/style.tsx
+++ b/pageStyle/edit-mypage/style.tsx
@@ -2,6 +2,20 @@ import styled from 'styled-components';
 
 const Layout = styled.div``;
 
-const S = { Layout };
+interface BackgroundProps {
+  isOpen: Boolean;
+}
+
+const Background = styled.div<BackgroundProps>`
+  background-color: ${(props) => props.theme.color.grey_00};
+  display: ${(props) => (props.isOpen ? 'block' : 'none')};
+  opacity: 0.3;
+  z-index: 3;
+  width: 100vw;
+  height: calc(100vh - 48px);
+  position: absolute;
+`;
+
+const S = { Layout, Background };
 
 export default S;

--- a/pages/edit-mypage/index.tsx
+++ b/pages/edit-mypage/index.tsx
@@ -3,12 +3,25 @@ import S from '@/pageStyle/edit-mypage/style';
 import { AiOutlineArrowLeft, AiOutlineSetting } from 'react-icons/ai';
 import { useRouter } from 'next/router';
 import Edit from '@/components/Domain/MyPage/Edit';
+import React, { FC, useEffect, useState } from 'react';
+import { Style } from '../add-ootd';
+import { AppLayoutProps } from '@/AppLayout';
 
-export default function MyPage() {
+interface ComponentWithLayout extends FC {
+  Layout?: FC<AppLayoutProps>;
+}
+
+const EditMyPage: ComponentWithLayout = () => {
   const router = useRouter();
+
+  const [openActionSheet, setOpenActionSheet] = useState<Boolean>(false);
 
   return (
     <>
+      <S.Background
+        isOpen={openActionSheet}
+        onClick={() => setOpenActionSheet(false)}
+      />
       <S.Layout>
         <AppBar
           leftProps={
@@ -20,8 +33,21 @@ export default function MyPage() {
           middleProps={<></>}
           rightProps={<></>}
         />
-        <Edit />
+        <Edit
+          openActionSheet={openActionSheet}
+          setOpenActionSheet={setOpenActionSheet}
+        />
       </S.Layout>
     </>
   );
-}
+};
+
+export default EditMyPage;
+
+export type { ComponentWithLayout, Style };
+
+EditMyPage.Layout = ({ children }: AppLayoutProps) => {
+  return <>{children}</>;
+};
+
+EditMyPage.Layout.displayName = 'NameLayout';


### PR DESCRIPTION
# 🔢 이슈 번호

- close #217

## ⚙ 작업 사항

- [ ] 내 정보 수정 페이지 바텀 네비게이션 바 삭제
- [ ] number input 의 unit에 padding-right 추가
- [ ] css 수정
 - 버튼 위치 수정 및 컴포넌트 사용
 - 백그라운드 수정
- [ ] 수정 성공 시 routing 경로 수정
- [ ] 수정 input의 warning 상태 삭제

## 📃 참고자료

-

## 📷 스크린샷
