### PR TITLE
전체적인 취소,뒤로가기 버튼 수정

### DIFF
--- a/components/ActionSheet/index.tsx
+++ b/components/ActionSheet/index.tsx
@@ -16,8 +16,12 @@ export default function ActionSheet({ buttons }: ActionSheetProps) {
       {buttons &&
         buttons.map((item, index) => {
           return (
-            <S.ButtonWrap key={index} name={item.name}>
-              <Button2 onClick={item.buttonClick}>{item.name}</Button2>
+            <S.ButtonWrap
+              onClick={item.buttonClick}
+              key={index}
+              name={item.name}
+            >
+              <Button2>{item.name}</Button2>
             </S.ButtonWrap>
           );
         })}

--- a/components/Domain/MyPage/BlockAlert/index.tsx
+++ b/components/Domain/MyPage/BlockAlert/index.tsx
@@ -1,7 +1,7 @@
 import Alert from '@/components/Alert';
 import { Body3, Title1 } from '@/components/UI';
 
-interface BlockAlertProps {
+export interface BlockAlertProps {
   blockUserName: string;
   onClickYesButton: () => void;
   onClickNoButton: () => void;

--- a/components/Domain/MyPage/Closet/ClosetEmpty/index.tsx
+++ b/components/Domain/MyPage/Closet/ClosetEmpty/index.tsx
@@ -1,0 +1,23 @@
+import { Body3, Button3 } from '@/components/UI';
+import S from './style';
+
+interface ClosetEmptyProps {
+  text: string;
+  button: string;
+  onClick: () => void;
+}
+
+export default function ClosetEmpty({
+  text,
+  button,
+  onClick,
+}: ClosetEmptyProps) {
+  return (
+    <S.Layout>
+      <Body3 className="text">{text}</Body3>
+      <button onClick={onClick} className="button">
+        <Button3> {button}</Button3>
+      </button>
+    </S.Layout>
+  );
+}

--- a/components/Domain/MyPage/Closet/ClosetEmpty/style.tsx
+++ b/components/Domain/MyPage/Closet/ClosetEmpty/style.tsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+
+const Layout = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  margin-top: 72px;
+  .text {
+    color: ${(props) => props.theme.color.grey_50};
+  }
+  .button {
+    width: 139px;
+    height: 36px;
+    border: 1px solid black;
+    border-radius: 2px;
+  }
+`;
+
+const S = { Layout };
+
+export default S;

--- a/components/Domain/MyPage/Closet/ClosetTabbar/index.tsx
+++ b/components/Domain/MyPage/Closet/ClosetTabbar/index.tsx
@@ -2,27 +2,27 @@ import { Body3, Caption1 } from '@/components/UI';
 import S from './style';
 
 interface ClosetTabbarProps {
-  OOTDNumber: number;
-  clothNumber: number;
+  ootdCount: number;
+  clothesCount: number;
   handleStep: (next: string) => void;
   currentStep: string;
 }
 
 export default function ClosetTabbar({
-  OOTDNumber,
-  clothNumber,
+  ootdCount,
+  clothesCount,
   handleStep,
   currentStep,
 }: ClosetTabbarProps) {
   return (
     <S.Layout>
       <S.OOTD onClick={() => handleStep('OOTD')}>
-        <Body3 state="emphasis">{OOTDNumber}</Body3>
+        <Body3 state="emphasis">{ootdCount}</Body3>
         <Caption1>OOTD</Caption1>
         {currentStep === 'OOTD' && <S.Hr />}
       </S.OOTD>
       <S.Closet onClick={() => handleStep('Cloth')}>
-        <Body3 state="emphasis">{clothNumber}</Body3>
+        <Body3 state="emphasis">{clothesCount}</Body3>
         <Caption1>옷</Caption1>
         {currentStep === 'Cloth' && <S.Hr />}
       </S.Closet>

--- a/components/Domain/MyPage/Closet/index.tsx
+++ b/components/Domain/MyPage/Closet/index.tsx
@@ -2,35 +2,55 @@ import { useFunnel } from '@/hooks/use-funnel';
 import S from './style';
 import ClosetTabbar from './ClosetTabbar';
 import ClosetCloth from './ClosetCloth';
-import ClosetOOTD, { MyPageOOTDType } from './ClosetOOTD';
-import { useEffect, useState } from 'react';
-import { OOTDApi } from '@/apis/domain/OOTD/OOTDApi';
-import { useRecoilValue } from 'recoil';
-import { userId } from '@/utils/recoil/atom';
+import ClosetOOTD from './ClosetOOTD';
+import ClosetEmpty from './ClosetEmpty';
+import { useRouter } from 'next/router';
 
 interface ClosetType {
-  localUserId: number;
   showingId: number;
+  ootdCount: number;
+  clothesCount: number;
 }
 
-export default function Closet({ localUserId, showingId }: ClosetType) {
+export default function Closet({
+  showingId,
+  ootdCount,
+  clothesCount,
+}: ClosetType) {
   const [Funnel, currentStep, handleStep] = useFunnel(['OOTD', 'Cloth']);
+  const router = useRouter();
 
   return (
     <>
       <S.Layout>
         <ClosetTabbar
-          OOTDNumber={2}
-          clothNumber={2}
+          ootdCount={ootdCount}
+          clothesCount={clothesCount}
           handleStep={handleStep}
           currentStep={currentStep}
         />
         <Funnel>
           <Funnel.Steps name="OOTD">
-            <ClosetOOTD />
+            {ootdCount === 0 ? (
+              <ClosetEmpty
+                text="공유하신 사진이 없습니다."
+                button="OOTD 게시하기"
+                onClick={() => router.push('/add-ootd')}
+              />
+            ) : (
+              <ClosetOOTD />
+            )}
           </Funnel.Steps>
           <Funnel.Steps name="Cloth">
-            <ClosetCloth showingId={showingId} />
+            {clothesCount === 0 ? (
+              <ClosetEmpty
+                text="옷장이 비어있습니다."
+                button="의류 추가하기"
+                onClick={() => router.push('/add-closet')}
+              />
+            ) : (
+              <ClosetCloth showingId={showingId} />
+            )}
           </Funnel.Steps>
         </Funnel>
       </S.Layout>

--- a/components/Domain/MyPage/OtherModal/index.tsx
+++ b/components/Domain/MyPage/OtherModal/index.tsx
@@ -1,0 +1,27 @@
+import ActionSheet from '@/components/ActionSheet';
+import { useState } from 'react';
+import BlockAlert, { BlockAlertProps } from '../BlockAlert';
+
+export default function OtherModal({
+  blockUserName,
+  onClickNoButton,
+  onClickYesButton,
+}: BlockAlertProps) {
+  const [blockAlertState, setBlockAlertState] = useState<Boolean>(false);
+
+  const buttons = [
+    { name: '사용자 차단', buttonClick: () => setBlockAlertState(true) },
+  ];
+  return (
+    <>
+      <ActionSheet buttons={buttons} />
+      {blockAlertState && (
+        <BlockAlert
+          blockUserName={blockUserName}
+          onClickNoButton={onClickNoButton}
+          onClickYesButton={onClickYesButton}
+        />
+      )}
+    </>
+  );
+}

--- a/components/Domain/MyPage/Profile/index.tsx
+++ b/components/Domain/MyPage/Profile/index.tsx
@@ -2,7 +2,6 @@ import { OtherProfile } from '@/components/Profile';
 import S from './style';
 import Button from '@/components/Button';
 import { Body3, Body4, Button3 } from '@/components/UI';
-import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 
 export interface UserProfileDataType {
@@ -15,8 +14,8 @@ export interface UserProfileDataType {
   weight: number;
   isFollow: Boolean;
   description: string;
-  OOTDNumber: number;
-  clothNumber: number;
+  ootdCount: number;
+  clothesCount: number;
 }
 
 interface profileProps {

--- a/pageStyle/mypage/style.tsx
+++ b/pageStyle/mypage/style.tsx
@@ -15,9 +15,10 @@ const Background = styled.div<BackgroundState>`
   background-color: ${(props) => props.theme.color.grey_00};
   display: ${(props) => (props.isOpen ? 'block' : 'none')};
   opacity: 0.3;
-  z-index: 900;
+  z-index: 2;
   width: 100vw;
-  height: 100vh;
+  height: 130vh;
+  top: 0;
   position: absolute;
 `;
 

--- a/pages/add-cloth/BasicInfoSecond/index.tsx
+++ b/pages/add-cloth/BasicInfoSecond/index.tsx
@@ -106,7 +106,7 @@ export default function BasicInfoSecond({
     };
 
     const result = await postCloth(payload);
-    if (result) router.push(`/mypage/${myId}`);
+    if (result) router.replace(`/mypage/${myId}`);
   };
 
   return (

--- a/pages/add-ootd/WriteOOTD/index.tsx
+++ b/pages/add-ootd/WriteOOTD/index.tsx
@@ -78,7 +78,7 @@ export default function WriteOOTD({
 
       //ootd 성공 여부에 따른 페이지 이동
       if (addOOTDSuccess) {
-        router.push(`/mypage/${myId}`);
+        router.replace(`/mypage/${myId}`);
       } else {
         alert('등록 실패');
       }

--- a/pages/add-ootd/index.tsx
+++ b/pages/add-ootd/index.tsx
@@ -45,7 +45,7 @@ const AddOOTD: ComponentWithLayout = () => {
   //앱바 왼쪽 네비게이션 클릭
   const onClickAppbarLeftButton = () => {
     if (currentStep === '편집') {
-      router.push('/name');
+      router.back();
     } else if (currentStep === '태그') {
       handleStep('편집');
     } else {

--- a/pages/bookmark/index.tsx
+++ b/pages/bookmark/index.tsx
@@ -142,7 +142,7 @@ export default function Bookmark() {
       <S.Background isOpen={alertOpen} onClick={onClickBackground} />
       <S.Layout>
         <AppBar
-          leftProps={<AiOutlineArrowLeft onClick={() => router.back()} />}
+          leftProps={<></>}
           middleProps={<Title1>북마크</Title1>}
           rightProps={<></>}
         />

--- a/pages/cloth/[...ClothNumber].tsx
+++ b/pages/cloth/[...ClothNumber].tsx
@@ -143,7 +143,7 @@ const Cloth = () => {
   return (
     <>
       <AppBar
-        leftProps={<AiOutlineArrowLeft />}
+        leftProps={<AiOutlineArrowLeft onClick={() => router.back()} />}
         middleProps={<></>}
         rightProps={<AiOutlineEllipsis onClick={onClickAppbarButton} />}
       />

--- a/pages/edit-cloth/[...ClothNumber].tsx
+++ b/pages/edit-cloth/[...ClothNumber].tsx
@@ -130,9 +130,7 @@ const EditCloth: ComponentWithLayout = () => {
   return (
     <Funnel>
       <AppBar
-        leftProps={
-          <Button3 onClick={() => router.push(`/detail-cloth`)}>취소</Button3>
-        }
+        leftProps={<Button3 onClick={() => router.back()}>취소</Button3>}
         middleProps={<Title1>수정하기</Title1>}
         rightProps={<></>}
       />

--- a/pages/edit-ootd/[...OOTDNumber].tsx
+++ b/pages/edit-ootd/[...OOTDNumber].tsx
@@ -109,7 +109,11 @@ const EditOOTD: ComponentWithLayout = () => {
       <AppBar
         leftProps={<></>}
         middleProps={<Title1>수정하기</Title1>}
-        rightProps={<Button3 style={{ color: 'red' }}>취소</Button3>}
+        rightProps={
+          <Button3 onClick={() => router.back()} style={{ color: 'red' }}>
+            취소
+          </Button3>
+        }
       />
       <S.Layout>
         <Body4 className="selectedPhoto" state="emphasis">

--- a/pages/mypage/[...UserId].tsx
+++ b/pages/mypage/[...UserId].tsx
@@ -14,8 +14,8 @@ import { userId } from '@/utils/recoil/atom';
 import { useRecoilValue } from 'recoil';
 import { UserApi } from '@/apis/domain/User/UserApi';
 import { UserProfileDataType } from '@/components/Domain/MyPage/Profile';
-import BlockAlert from '@/components/Domain/MyPage/BlockAlert';
 import { PublicApi } from '@/apis/domain/Public/PublicApi';
+import OtherModal from '@/components/Domain/MyPage/OtherModal';
 
 export default function MyPage() {
   const router = useRouter();
@@ -36,11 +36,9 @@ export default function MyPage() {
     weight: 72,
     isFollow: false,
     description: '간계밥',
-    OOTDNumber: 0,
-    clothNumber: 0,
+    ootdCount: 0,
+    clothesCount: 0,
   });
-
-  const [followState, setFollowState] = useState<Boolean>(false);
 
   const { getMypage } = UserApi();
   const { follow, unFollow } = PublicApi();
@@ -121,15 +119,20 @@ export default function MyPage() {
           showingId={showingId}
           onClickFollowButton={onClickFollowButton}
         />
-        <Closet localUserId={localUserId} showingId={showingId} />
+        <Closet
+          showingId={showingId}
+          ootdCount={userProfileData.ootdCount}
+          clothesCount={userProfileData.clothesCount}
+        />
         {queryState === 'editSuccess' && (
           <Toast text="프로필이 수정되었습니다." />
         )}
+
         {blockOpen && (
-          <BlockAlert
+          <OtherModal
             blockUserName={userProfileData.userName}
-            onClickYesButton={onClickYesButton}
             onClickNoButton={onClickNoButton}
+            onClickYesButton={onClickYesButton}
           />
         )}
       </S.Layout>

--- a/pages/sign-in/[...callback].tsx
+++ b/pages/sign-in/[...callback].tsx
@@ -23,11 +23,11 @@ export default function SignUpCallbackPage() {
         // login 함수 호출 이후에 상태 확인 및 라우팅
         switch (loginSuccess) {
           case true:
-            if (await getCheckCompleteRegistUserInfo()) router.push('/main');
-            else router.push('/sign-up');
+            if (await getCheckCompleteRegistUserInfo()) router.replace('/main');
+            else router.replace('/sign-up');
             break;
           case false:
-            router.push('../sign-in');
+            router.replace('../sign-in');
             break;
           default:
           // 상태가 정의되지 않은 경우에 대한 처리


### PR DESCRIPTION
# 🔢 이슈 번호

- close #225 

## ⚙ 작업 사항

- [x] 기존 `router.push` 에서 `router.replace` 로 변경
- [x] 뒤로가기 버튼에 `router.back` 추가
- [x] 북마크 페이지 뒤로가기 버튼 삭제  

## 📃 참고자료

`add-cloth` 페이지에서 옷 등록을 완료하고 마이페이지로 갈 경우 뒤로 가기 버튼을 누르면 다시 `add-cloth` 페이지로 가는 현상이 있었는데요!
- 기존 `router.push`는  기존 라우터 stack에 push 를 하는 개념이고
- 바꾼 `router.replace`는 기존 라우터 stack의 마지막 인덱스를 바꾸는 개념이라 

뒤로 가기 버튼 클릭을 해도 `add-cloth` 전의 화면으로 돌아갑니다!

https://velog.io/@e_juhee/Router-Router.push%EC%99%80-Router.replace%EC%9D%98-%EC%B0%A8%EC%9D%B4

## 📷 스크린샷
