### PR TITLE
유저 정보 입력 관련 수정

### DIFF
--- a/components/Domain/SignUp/AgeInput/index.tsx
+++ b/components/Domain/SignUp/AgeInput/index.tsx
@@ -3,14 +3,16 @@ import S from './style';
 
 interface InputComponentProps {
   onChange: (value: string) => void;
+  age: string;
 }
 
-export default function AgeInput({ onChange }: InputComponentProps) {
+export default function AgeInput({ onChange, age }: InputComponentProps) {
   return (
     <Input>
       <S.Layout>
         <Input.Label size="big">나이</Input.Label>
         <Input.Text
+          defaultValue={age}
           line="underline"
           size="small"
           unit="세"

--- a/components/Domain/SignUp/BodyInput/index.tsx
+++ b/components/Domain/SignUp/BodyInput/index.tsx
@@ -5,11 +5,15 @@ import S from './style';
 interface BodyInputProps {
   heightSetState: Dispatch<SetStateAction<string>>;
   weightSetState: Dispatch<SetStateAction<string>>;
+  weight: string;
+  height: string;
 }
 
 export default function BodyInput({
   heightSetState,
   weightSetState,
+  weight,
+  height,
 }: BodyInputProps) {
   return (
     <Input>
@@ -19,6 +23,7 @@ export default function BodyInput({
           <S.Weight>
             <Input.Label size="small">신장</Input.Label>
             <Input.Text
+              defaultValue={height}
               line="underline"
               size="small"
               unit="cm"
@@ -30,6 +35,7 @@ export default function BodyInput({
           <S.Height>
             <Input.Label size="small">몸무게</Input.Label>
             <Input.Text
+              defaultValue={weight}
               line="underline"
               size="small"
               unit="kg"

--- a/components/Domain/SignUp/IdInput/index.tsx
+++ b/components/Domain/SignUp/IdInput/index.tsx
@@ -24,9 +24,10 @@ import { RegisterApi } from '@/apis/domain/Register/RegisterApi';
 interface InputProps {
   setInput: Dispatch<SetStateAction<string>>;
   setCanUseId: Dispatch<SetStateAction<Boolean>>;
+  id: string;
 }
 
-export default function IdInput({ setInput, setCanUseId }: InputProps) {
+export default function IdInput({ setInput, setCanUseId, id }: InputProps) {
   const [helperText, setHelperText] = useState<string>('입력해주세요');
   const [state, setState] = useState<number>(1);
   const { checkName } = RegisterApi();
@@ -81,15 +82,18 @@ export default function IdInput({ setInput, setCanUseId }: InputProps) {
       <Input>
         <Input.Label size="big">닉네임</Input.Label>
         <Input.Text
+          defaultValue={id}
           line="underline"
           size="big"
           placeholder={NICKNAME_PLACEHODER}
           validity={idInputValidity}
           onChange={setInput}
         />
-        <Input.HelperText className="helperText" state={state}>
-          {helperText}
-        </Input.HelperText>
+        {id.length > 0 && (
+          <Input.HelperText className="helperText" state={state}>
+            {helperText}
+          </Input.HelperText>
+        )}
       </Input>
     </S.Layout>
   );

--- a/components/Domain/SignUp/IdInput/index.tsx
+++ b/components/Domain/SignUp/IdInput/index.tsx
@@ -89,7 +89,7 @@ export default function IdInput({ setInput, setCanUseId, id }: InputProps) {
           validity={idInputValidity}
           onChange={setInput}
         />
-        {id.length > 0 && (
+        {id?.length > 0 && (
           <Input.HelperText className="helperText" state={state}>
             {helperText}
           </Input.HelperText>

--- a/components/Input/Text/style.tsx
+++ b/components/Input/Text/style.tsx
@@ -71,6 +71,9 @@ const Input = styled.input<InputProps>`
   font-family: 'Pretendard Regular';
   text-decoration: ${(props) =>
     props.type === 'Link' ? '1px solid underline' : ''};
+  &::placeholder {
+    color: ${(props) => props.theme.color.grey_80};
+  }
   ${(props) =>
     props.line === 'underline' &&
     `
@@ -116,6 +119,7 @@ const CloseIcon = styled(FlexLayout)<InputProps>`
   align-items: center;
   display: flex;
   width: 24px;
+  flex-shrink: 0;
   svg {
     width: 12px;
     height: 12px;

--- a/hooks/regex.ts
+++ b/hooks/regex.ts
@@ -1,5 +1,6 @@
 // 한글 초성 단독 사용 불가
-export const hasKoreanInitial = (value: string) => /[ㄱ-ㅎ]/g.test(value);
+export const hasKoreanInitial = (value: string) =>
+  /[ㄱ-ㅎㅏㅑㅓㅕㅗㅛㅜㅠㅡㅣㅢㅟㅚㅞㅝ]/g.test(value);
 
 // 특수문자 사용 단독사용 불가
 export const hasSpecialCharacter = (value: string) =>
@@ -13,7 +14,35 @@ export const isMoreThan12Length = (value: string) => value?.length > 12;
 export const isMoreThan2Length = (value: string) => value?.length < 2;
 
 //욕설을 포함하면 사용 불가
-const 욕설리스트 = ['바보', '멍청이', '이바름'];
+const 욕설리스트 = [
+  '간나',
+  '개년, 개돼지, 개새끼, 개쓰레기, 개소리, 개씹, 개좆, 개자식',
+  '걸레',
+  '게이',
+  '고자',
+  '꺼져',
+  '남창',
+  '니애미',
+  '니미',
+  '니애비',
+  '니기미',
+  '닥쳐',
+  '쓰레기',
+  '머저리',
+  '미친',
+  '변태',
+  '병신',
+  '시발',
+  '새끼',
+  '씨발',
+  '씹',
+  '아가리',
+  '염병',
+  '장애인',
+  '좆',
+  '지랄',
+  '호구',
+];
 
 export const badNickname = (value: string) => {
   let flag = true;

--- a/pages/sign-up/BasicInfo/index.tsx
+++ b/pages/sign-up/BasicInfo/index.tsx
@@ -7,17 +7,21 @@ interface BasicInfoProps {
   setId: Dispatch<SetStateAction<string>>;
   setAge: Dispatch<SetStateAction<string>>;
   setCanUseId: Dispatch<SetStateAction<Boolean>>;
+  id: string;
+  age: string;
 }
 
 export default function BasicInfo({
   setId,
   setAge,
   setCanUseId,
+  id,
+  age,
 }: BasicInfoProps) {
   return (
     <S.Layout>
-      <IdInput setInput={setId} setCanUseId={setCanUseId} />
-      <AgeInput onChange={setAge} />
+      <IdInput id={id} setInput={setId} setCanUseId={setCanUseId} />
+      <AgeInput age={age} onChange={setAge} />
     </S.Layout>
   );
 }

--- a/pages/sign-up/BodyInfo/index.tsx
+++ b/pages/sign-up/BodyInfo/index.tsx
@@ -8,6 +8,8 @@ interface BodyInfoProps {
   setOpen: Dispatch<SetStateAction<Boolean>>;
   heightSetState: Dispatch<SetStateAction<string>>;
   weightSetState: Dispatch<SetStateAction<string>>;
+  weight: string;
+  height: string;
 }
 
 export default function BodyInfo({
@@ -15,10 +17,14 @@ export default function BodyInfo({
   setOpen,
   heightSetState,
   weightSetState,
+  weight,
+  height,
 }: BodyInfoProps) {
   return (
     <S.Layout>
       <BodyInput
+        weight={weight}
+        height={height}
         heightSetState={heightSetState}
         weightSetState={weightSetState}
       />

--- a/pages/sign-up/index.tsx
+++ b/pages/sign-up/index.tsx
@@ -93,7 +93,6 @@ const SignUp: ComponentWithLayout = () => {
               // 스타일 컴포넌트를 사용하여 스타일 적용
               currentStep === stepName ? (
                 <S.ActiveStep key={stepName}>
-                  {' '}
                   <S.Progress>
                     <div className="number">
                       <Title1>0{index + 1}.</Title1>
@@ -116,6 +115,8 @@ const SignUp: ComponentWithLayout = () => {
           <S.Main>
             <Funnel.Steps name="기본정보">
               <BasicInfo
+                id={id}
+                age={age}
                 setId={setId}
                 setAge={setAge}
                 setCanUseId={setCanUseId}
@@ -130,6 +131,8 @@ const SignUp: ComponentWithLayout = () => {
             </Funnel.Steps>
             <Funnel.Steps name="체형정보">
               <BodyInfo
+                weight={weight}
+                height={height}
                 heightSetState={setHeight}
                 weightSetState={setWeight}
                 open={open}


### PR DESCRIPTION
# 🔢 이슈 번호

- close #227 

## ⚙ 작업 사항

- [x] close button 터치영역이 작아지는 버그 수정
- [x] placeholder 색상 수정
- [x] 닉네임에 자음 단독 사용 필터링
- [x] 닉네임에 욕설 필터링
- [x] 회원가입 도중 이전 단계로 돌아가도 입력 값 유지

## 📃 참고자료

- [욕설 리스트] https://namu.wiki/w/%EC%9A%95%EC%84%A4/%ED%95%9C%EA%B5%AD%EC%96%B4

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/125d51f1-b9ee-4c2d-9760-a1777018c0a8)
![image](https://github.com/ootd-zip/client/assets/158991486/decf7522-e45e-43bd-b499-1c35fcddfaf0)
