### PR TITLE
스플래시 스크린 유저 아이디 API 연동 및 라우팅 설정

### DIFF
--- a/apis/_api/auth.ts
+++ b/apis/_api/auth.ts
@@ -39,3 +39,9 @@ export const getCheckCompleteRegistUserInfo = async () => {
 
   return data;
 };
+
+export const getUserId = async () => {
+  const { data } = await fetcher.get('/api/v1/user/token/info');
+
+  return data;
+};

--- a/apis/_service/auth.service.ts
+++ b/apis/_service/auth.service.ts
@@ -26,3 +26,9 @@ export const getCheckCompleteRegistUserInfo = async () => {
 
   return data;
 };
+
+export const getUserId = async () => {
+  const data = await authApi.getUserId();
+
+  return data;
+};

--- a/apis/domain/Public/PublicApi.tsx
+++ b/apis/domain/Public/PublicApi.tsx
@@ -1,4 +1,4 @@
-import { userService } from '@/apis/_service';
+import { authService, userService } from '@/apis/_service';
 
 export const PublicApi = () => {
   const follow = async (id: number) => {
@@ -11,8 +11,14 @@ export const PublicApi = () => {
     return data;
   };
 
+  const getUserId = async () => {
+    const { result } = await authService.getUserId();
+
+    return result;
+  };
   return {
     follow,
     unFollow,
+    getUserId,
   } as const;
 };

--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/splash-screen',
+        permanent: true,
+      },
+    ]
+  },
   reactStrictMode: false,
   compiler: {
     styledComponents: true,

--- a/pages/onboarding/index.tsx
+++ b/pages/onboarding/index.tsx
@@ -22,7 +22,7 @@ const Onboarding: ComponentWithLayout = () => {
         </Body3>
       </S.TypoGraphy>
       <Button
-        onClick={() => router.push('/main')}
+        onClick={() => router.push('/sign-in')}
         size="big"
         backgroundColor="accent"
         color="grey_00"

--- a/pages/sign-in/[...callback].tsx
+++ b/pages/sign-in/[...callback].tsx
@@ -23,7 +23,8 @@ export default function SignUpCallbackPage() {
         // login 함수 호출 이후에 상태 확인 및 라우팅
         switch (loginSuccess) {
           case true:
-            if (await getCheckCompleteRegistUserInfo()) router.replace('/main');
+            if (await getCheckCompleteRegistUserInfo())
+              router.replace('/splash-screen');
             else router.replace('/sign-up');
             break;
           case false:

--- a/pages/splash-screen/index.tsx
+++ b/pages/splash-screen/index.tsx
@@ -5,14 +5,21 @@ import { AppLayoutProps } from '@/AppLayout';
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { getCookie } from '@/utils/Cookie';
+import { PublicApi } from '@/apis/domain/Public/PublicApi';
+import { useSetRecoilState } from 'recoil';
+import { userId } from '@/utils/recoil/atom';
 
 const SplashScreen: ComponentWithLayout = () => {
   const router = useRouter();
+  const { getUserId } = PublicApi();
+  const setUserId = useSetRecoilState(userId);
 
   useEffect(() => {
-    const timer = setTimeout(() => {
+    const timer = setTimeout(async () => {
       if (getCookie('accessToken')) {
+        const { id } = await getUserId();
         router.push('/main');
+        setUserId(id);
         return;
       }
       router.push('/onboarding');

--- a/utils/recoil/atom.tsx
+++ b/utils/recoil/atom.tsx
@@ -22,6 +22,6 @@ export const storedImageKey = atom<ImageWithTag | undefined>({
 
 export const userId = atom<number>({
   key: 'userId',
-  default: 3,
+  default: 0,
   effects_UNSTABLE: [persistAtom],
 });


### PR DESCRIPTION
# 🔢 이슈 번호

- #close 238

## ⚙ 작업 사항

- [x] 스플래시 스크린 유저 아이디 API 연동 
- [x] 스플래시 스크린 라우팅 설정
- [x] / 경로를 splash-screen으로 redirect 

## 📃 참고자료

-

## 📷 스크린샷
