### PR TITLE
ootd 상세페이지 수정

### DIFF
--- a/apis/_api/cloth.ts
+++ b/apis/_api/cloth.ts
@@ -22,8 +22,8 @@ export const getUserClothList = async ({
   colorIds,
   isPrivate,
   searchText,
-}: getClothListParams) => { 
-  let url = `/api/v1/clothes?page=${page}&size=${size}&userId=${userId}&sortCriteria=createdAt&sortDirection=DESC&searchText=${searchText}`; 
+}: getClothListParams) => {
+  let url = `/v1/clothes?page=${page}&size=${size}&userId=${userId}&sortCriteria=createdAt&sortDirection=DESC`;
   const brandUrl = brandIds?.map((item) => `brandIds=${item}`).join('&');
   const categoryUrl = categoryIds
     ?.map((item) => `categoryIds=${item}`)
@@ -36,6 +36,7 @@ export const getUserClothList = async ({
   if (categoryUrl) url += `&${categoryUrl}`;
   if (colorUrl) url += `&${colorUrl}`;
   if (isPrivateUrl) url += `&${isPrivateUrl}`;
+  if (searchText) url += `&searchText=${searchText}`;
 
   const { data } = await fetcher.get(url);
 

--- a/components/Comment/index.tsx
+++ b/components/Comment/index.tsx
@@ -64,7 +64,7 @@ function Comment({
     <>
       <S.Layout type={type}>
         <S.CommentLeft>
-          {userImage == null ? (
+          {userImage === '' ? (
             <Avatar className="avatar" />
           ) : (
             <S.UserImage>

--- a/components/Posting/index.tsx
+++ b/components/Posting/index.tsx
@@ -183,7 +183,7 @@ export default function Posting({
       />
       <S.Layout>
         <S.PostingTop>
-          {data.userName === 'string' ? (
+          {data.userImage !== '' ? (
             <img
               onClick={() => router.push(`/mypage/${data.userId}`)}
               src={data.userImage}

--- a/components/PostingComment/PostingCommentWrite/index.tsx
+++ b/components/PostingComment/PostingCommentWrite/index.tsx
@@ -47,10 +47,10 @@ export default function PostingCommentWrite({
 
       <S.CommentWrite>
         <S.UserImage>
-          {userImage === null ? (
+          {userImage === '' ? (
             <Avatar className="avatar" />
           ) : (
-            <img src={userImage} alt="유저 프로필 이미지" />
+            <img src={userImage!} alt="유저 프로필 이미지" />
           )}
         </S.UserImage>
         <S.Comment>


### PR DESCRIPTION
# 🔢 이슈 번호

- close #252

## ⚙ 작업 사항

- [x] 유저 프로필이 비어있을때 기존 `null`에서 `''` 을 서버에서 주기로 변경
- [x] **유저의 옷 조회 API** `searchText` 유무에 따른 `url` 변경


## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/38fa3e24-3355-4d51-9a2f-148c7eae06bd)
