### PR TITLE
ootd 상세 페이지 css 수정

### DIFF
--- a/components/Comment/index.tsx
+++ b/components/Comment/index.tsx
@@ -85,9 +85,9 @@ function Comment({
             <Caption1 className="createAt">{timeStamp}</Caption1>
           </S.UserName>
           <S.UserComment>
-            <Body3 className="taggedUser">
-              {taggedUserName && `@${taggedUserName}`}&nbsp;
-            </Body3>
+            {taggedUserName && (
+              <Body3 className="taggedUser">@{taggedUserName}</Body3>
+            )}
             <Body3>{content}</Body3>
           </S.UserComment>
           {view !== 'preview' ? (

--- a/components/Comment/index.tsx
+++ b/components/Comment/index.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { Body3, Caption1 } from '../UI';
 import S from './style';
 import Avatar from '@/public/images/Avatar.svg';
@@ -73,8 +73,8 @@ function Comment({
                 src={userImage}
                 alt="유저 이미지"
                 fill={false}
-                width={32}
-                height={32}
+                width={type === 'child' ? 24 : 32}
+                height={type === 'child' ? 24 : 32}
               />
             </S.UserImage>
           )}

--- a/components/Comment/style.tsx
+++ b/components/Comment/style.tsx
@@ -39,7 +39,10 @@ const UserName = styled.div`
 const UserComment = styled.div`
   .taggedUser {
     color: ${(prpos) => prpos.theme.color.correct};
+    padding: 0 4px;
+    margin-right: 4px;
   }
+  white-space: pre-line;
   display: flex;
   color: ${(props) => props.theme.color.grey_30};
   padding: 2px 0 16px 0;

--- a/components/Domain/OOTD/UserCloth/index.tsx
+++ b/components/Domain/OOTD/UserCloth/index.tsx
@@ -43,7 +43,6 @@ export default function UserCloth({ userName, userId }: UserClothProps) {
   });
 
   useEffect(() => {
-    console.log(userClothData);
     setData(userClothData);
   }, [userClothData]);
 
@@ -52,7 +51,7 @@ export default function UserCloth({ userName, userId }: UserClothProps) {
     <S.Layout>
       <S.Title>
         <Title1>{userName}님의 옷장</Title1>
-        <Button3 onClick={() => router.push(`/mypage/${userId}`)}>
+        <Button3 onClick={() => router.push(`/mypage/${userId}/cloth`)}>
           더보기
         </Button3>
       </S.Title>

--- a/components/NextImage/index.tsx
+++ b/components/NextImage/index.tsx
@@ -6,7 +6,6 @@ interface ImageProps {
   alt: string;
   fill: boolean;
   className?: string;
-  key?: number;
   width?: number;
   height?: number;
   ref?: MutableRefObject<HTMLImageElement | null>;
@@ -18,7 +17,6 @@ export default function NextImage({
   alt,
   fill,
   className,
-  key,
   width,
   height,
   onClick,
@@ -32,7 +30,6 @@ export default function NextImage({
       style={{ objectFit: 'cover' }}
       className={className}
       onClick={onClick}
-      key={key}
       width={width}
       height={height}
       ref={ref}

--- a/components/Posting/index.tsx
+++ b/components/Posting/index.tsx
@@ -317,11 +317,13 @@ export default function Posting({
               );
             })}
         </S.PostingStyleTag>
-        <ReportModal
-          reportModalIsOpen={reportModalIsOpen}
-          setReportModalIsOpen={setReportModalIsOpen}
-          setDeclaration={setDeclaration}
-        />
+        {reportModalIsOpen && (
+          <ReportModal
+            reportModalIsOpen={reportModalIsOpen}
+            setReportModalIsOpen={setReportModalIsOpen}
+            setDeclaration={setDeclaration}
+          />
+        )}
         <FixModal
           setToastOpen={setToastOpen}
           reportModalIsOpen={fixModalIsOpen}

--- a/components/Posting/style.tsx
+++ b/components/Posting/style.tsx
@@ -74,7 +74,7 @@ const PostingImage = styled.div`
   padding-bottom: 100%;
   .tag {
     position: absolute;
-    z-index: 999;
+    z-index: 1;
     left: 16px;
     bottom: 16px;
     color: white;

--- a/components/Posting/style.tsx
+++ b/components/Posting/style.tsx
@@ -24,7 +24,13 @@ const Layout = styled.div`
   }
   border-bottom: 1px solid ${(props) => props.theme.color.grey_95};
   .slick-dots {
-    bottom: -35px;
+    bottom: -30px;
+
+    & li {
+      width: 6px;
+      height: 6px;
+      margin: 2px;
+    }
   }
 `;
 

--- a/components/PostingComment/PostingCommentWrite/index.tsx
+++ b/components/PostingComment/PostingCommentWrite/index.tsx
@@ -80,7 +80,7 @@ export default function PostingCommentWrite({
         <S.Comment>
           <S.Text>
             <S.Input
-              line={Math.floor(comment.content.length / 21) + 2}
+              line={comment.content.split('\n').length}
               ref={commentRef}
               onChange={(e) => {
                 setComment({ ...comment, content: e.target.value });

--- a/components/PostingComment/PostingCommentWrite/index.tsx
+++ b/components/PostingComment/PostingCommentWrite/index.tsx
@@ -1,14 +1,20 @@
 import { Body3, Button3 } from '@/components/UI';
 import S from './style';
-import { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+  useEffect,
+  useState,
+} from 'react';
 import { CommentStateType } from '@/pages/ootd/[...OOTDNumber]';
 import { AiFillCloseCircle } from 'react-icons/ai';
 import Avatar from '@/public/images/Avatar.svg';
 import NextImage from '@/components/NextImage';
+import { UserApi } from '@/apis/domain/User/UserApi';
 
 interface PostingCommentWriteProps {
   comment: CommentStateType;
-  userImage: string | null;
   setComment: Dispatch<SetStateAction<CommentStateType>>;
   commentRef: MutableRefObject<null>;
   commentWriting: Boolean;
@@ -18,7 +24,6 @@ interface PostingCommentWriteProps {
 }
 export default function PostingCommentWrite({
   comment,
-  userImage,
   setComment,
   commentRef,
   commentWriting,
@@ -26,6 +31,19 @@ export default function PostingCommentWrite({
   registerComment,
   setCommentFinish,
 }: PostingCommentWriteProps) {
+  const { getProfile } = UserApi();
+
+  const [userImage, setUserImage] = useState<string | null>(null);
+
+  const fetchData = async () => {
+    const data = await getProfile();
+    setUserImage(data.profileImage);
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
   return (
     <S.Layout>
       {commentWriting && (
@@ -54,7 +72,7 @@ export default function PostingCommentWrite({
               fill={false}
               width={32}
               height={32}
-              src={userImage!}
+              src={userImage}
               alt="유저 프로필 이미지"
             />
           )}

--- a/components/PostingComment/PostingCommentWrite/index.tsx
+++ b/components/PostingComment/PostingCommentWrite/index.tsx
@@ -90,9 +90,11 @@ export default function PostingCommentWrite({
               value={comment.content}
             />
           </S.Text>
-          <S.Upload>
-            <Button3 onClick={registerComment}>등록</Button3>
-          </S.Upload>
+          {comment.content.length > 0 && (
+            <S.Upload>
+              <Button3 onClick={registerComment}>등록</Button3>
+            </S.Upload>
+          )}
         </S.Comment>
       </S.CommentWrite>
     </S.Layout>

--- a/components/PostingComment/PostingCommentWrite/style.tsx
+++ b/components/PostingComment/PostingCommentWrite/style.tsx
@@ -8,13 +8,14 @@ const Layout = styled.div`
 `;
 const CommentWriteState = styled.div`
   background-color: ${(props) => props.theme.color.grey_95};
-  padding: 12px 16px;
+  padding: 13px 16px;
   display: flex;
   gap: 2px;
   position: relative;
   color: ${(props) => props.theme.color.grey_30};
   display: flex;
   align-items: center;
+  border: 1px solid #03030302;
 
   .taggedUserName {
     font-weight: 600;
@@ -58,6 +59,11 @@ const Comment = styled.div`
 `;
 const Text = styled.div`
   width: 100%;
+  background-color: #f3f3f3;
+  border-radius: 22px;
+  max-height: 84px;
+  border: 1px solid #dbdbdb;
+  margin: 16px 0;
 `;
 interface InputProps {
   line: number;
@@ -74,11 +80,10 @@ const Input = styled.textarea<InputProps>`
   line-height: 20px;
   resize: none;
   height: calc(20px * ${(props) => props.line});
-  border: 1px solid ${(props) => props.theme.color.grey_90};
-  max-height: 84px;
+  max-height: 60px;
   display: flex;
   align-items: flex-end;
-  padding-top: 8px;
+  margin: 8px 0;
   &:focus {
     outline: none;
   }

--- a/components/PostingComment/index.tsx
+++ b/components/PostingComment/index.tsx
@@ -24,6 +24,7 @@ interface PostingCommentData extends CommentProps {
     parentId?: number;
     taggedUserName?: string;
     depth?: number;
+    userId: number;
   }[];
 }
 
@@ -150,7 +151,7 @@ export default function PostingComment({
               item.childComment?.map((items, indexs) => (
                 <Comment
                   key={items.id}
-                  userId={item.userId}
+                  userId={items.userId}
                   userImage={items.userImage}
                   id={items.id}
                   userName={items.userName}
@@ -164,7 +165,7 @@ export default function PostingComment({
                   type="child"
                   taggedUserName={items.taggedUserName}
                   timeStamp={items.timeStamp}
-                  myComment={localUserId === item.userId}
+                  myComment={localUserId === items.userId}
                   reRender={reRender}
                   setReRender={setReRender}
                 />

--- a/components/PostingComment/index.tsx
+++ b/components/PostingComment/index.tsx
@@ -54,6 +54,8 @@ export default function PostingComment({
     if (commentType === 'all') setCommentType('preview');
   };
   const [data, setData] = useState<PostingCommentData[]>([]);
+  const [totalCount, setTotalCount] = useState<Number>(0);
+
   const { getOOTDComment } = OOTDApi();
 
   useEffect(() => {
@@ -66,6 +68,8 @@ export default function PostingComment({
       });
       const map = new Map<number, PostingCommentData>();
       const resultData: PostingCommentData[] = [];
+
+      setTotalCount(content.length);
 
       content.forEach((comment: PostingCommentData) => {
         if (comment.depth === 1) map.set(comment.id, comment);
@@ -129,7 +133,7 @@ export default function PostingComment({
   const ComentAll = () => {
     return (
       <S.Layout>
-        <Body4 className="commentLength">총{data!.length}개의 댓글</Body4>
+        <Body4 className="commentLength">총{String(totalCount)}개의 댓글</Body4>
         {data!.map((item, index) => (
           <>
             <Comment

--- a/pages/ootd/[...OOTDNumber].tsx
+++ b/pages/ootd/[...OOTDNumber].tsx
@@ -173,7 +173,6 @@ const OOTD: ComponentWithLayout = () => {
       {data && <UserOtherOOTD userName={data.userName} userId={data.userId} />}
       <SimilarOOTD />
       <PostingCommentWrite
-        userImage={data && data.userImage}
         setComment={setComment}
         commentRef={commentRef}
         comment={comment}

--- a/styles/colors/index.ts
+++ b/styles/colors/index.ts
@@ -2,7 +2,7 @@ const color = {
   subdued: '#b2f8ff',
   accent: '#58efff',
   error: '#ec0000',
-  correct: '#00d5bb',
+  correct: '#13ddf3',
   preferred: '#007aff',
   grey_100: '#ffffff',
   grey_95: '#f3f3f3',


### PR DESCRIPTION
# 🔢 이슈 번호

- close #301

## ⚙ 작업 사항

- [x] Carousel 인디케이터 간격 조절
- [x] 태그 버튼 z-index 수정
- [x] 댓글 작성자에 ootd 작성자 프로필 사진이 들어가는 버그 수정
- [x] 대댓글 들여쓰기 제거
- [x] 댓글 작성란 필드 레이아웃 잡기
- [x] 댓글 작성란 등록 버튼 렌더링 조건 추가
- [x] 대댓글 작성 상태의 border 추가
- [x] ReportModal 렌더링 조건 추가
- [x] correct 디자인 시스템 색상 변경
- [x] 댓글과 답글 프로필 사진 크기 구분
- [x] 댓글 개수 수정
- [x] ~~님의 옷장의 더보기 클릭 시 마이페이지의 옷이 먼저 렌더링되게 하기


## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/07d31330-92f8-4725-afd8-86d0d17d6d7d)
![image](https://github.com/ootd-zip/client/assets/158991486/6544a3e5-b27c-4e01-b745-1e0d6924c132)
