### PR TITLE
메인페이지 API 연동 및 초기 렌더링 컨텐츠 수정

### DIFF
--- a/apis/_api/ootd.ts
+++ b/apis/_api/ootd.ts
@@ -201,3 +201,9 @@ export const getLikeOOTD = async () => {
 
   return data;
 };
+
+export const getSameClothDifferentOOTD = async () => {
+  const { data } = await fetcher.get('v1/home/scdf?page=0&size=4');
+
+  return data;
+};

--- a/apis/_service/user.service.ts
+++ b/apis/_service/user.service.ts
@@ -326,3 +326,9 @@ export const getLikeOOTD = async () => {
 
   return data;
 };
+
+export const getSameClothDifferentOOTD = async () => {
+  const data = await ootdApi.getSameClothDifferentOOTD();
+
+  return data;
+};

--- a/apis/domain/Main/MainApi.tsx
+++ b/apis/domain/Main/MainApi.tsx
@@ -11,7 +11,20 @@ export const MainApi = () => {
       console.log('에러명', err);
     }
   };
+
+  const getSameClothDifferentOOTD = async () => {
+    try {
+      const data = await userService.getSameClothDifferentOOTD();
+      if (data.statusCode === 200) return data.result;
+      return data;
+    } catch (err) {
+      alert('관리자에게 문의하세요');
+      console.log('에러명', err);
+    }
+  };
+
   return {
     getLikeOOTD,
+    getSameClothDifferentOOTD,
   } as const;
 };

--- a/components/Domain/Main/Explore/index.tsx
+++ b/components/Domain/Main/Explore/index.tsx
@@ -18,7 +18,7 @@ export default function Explore() {
   const router = useRouter();
 
   const onClickImageList = (index: number) => {
-    router.push(`/ootd/${index}`);
+    router.push(`/ootd/${index}/explore`);
   };
 
   const [sortStandard, setSortStandard] = useState<string>('LATEST');

--- a/components/Domain/Main/LikeOOTD/index.tsx
+++ b/components/Domain/Main/LikeOOTD/index.tsx
@@ -12,7 +12,7 @@ export default function LikeOOTD() {
   const router = useRouter();
 
   const onClickCard = (ootdId: number) => {
-    router.push(`/ootd/${ootdId}`);
+    router.push(`/ootd/${ootdId}/curation`);
   };
 
   const { getLikeOOTD } = MainApi();

--- a/components/Domain/Main/SameCloth/index.tsx
+++ b/components/Domain/Main/SameCloth/index.tsx
@@ -1,25 +1,52 @@
-/* eslint-disable @next/next/no-img-element */
 import { Body3, Button3, Headline2, Title2 } from '@/components/UI';
 import S from './style';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Button from '@/components/Button';
+import { MainApi } from '@/apis/domain/Main/MainApi';
+import NextImage from '@/components/NextImage';
+import { useRouter } from 'next/router';
 
-interface SameClothProps {
-  data: {
-    clothid: number;
-    image: string;
-    category: string;
+type SameClothData = {
+  clothes: {
+    id: number;
     name: string;
+    categoryType: string;
+    imageUrl: string;
+  };
+  ootdImages: {
+    ootdId: number;
+    imageUrl: string;
   }[];
-}
+}[];
 
-export default function SameCloth({ data }: SameClothProps) {
+export default function SameCloth() {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
+  const [sameClothData, setSameClothData] = useState<SameClothData | null>(
+    null
+  );
+
+  const { getSameClothDifferentOOTD } = MainApi();
+
+  const fetchDataFunction = async () => {
+    const { content } = await getSameClothDifferentOOTD();
+
+    setSameClothData(content);
+  };
 
   const onClickImage = (index: number) => {
     setCurrentIndex(index);
   };
+
+  const router = useRouter();
+
+  const onClickListImage = (ootdId: number) => {
+    router.push(`/ootd/${ootdId}/curation`);
+  };
+
+  useEffect(() => {
+    fetchDataFunction();
+  }, []);
 
   return (
     <S.Layout>
@@ -30,56 +57,93 @@ export default function SameCloth({ data }: SameClothProps) {
         </Body3>
       </S.Label>
       <S.Filter>
-        {data.map((item, index) => {
-          return (
-            <S.FilterItem
-              onTouchMove={(e) => e.stopPropagation()}
-              key={index}
-              state={index === currentIndex}
-            >
-              <Image
-                onClick={() => onClickImage(index)}
-                width={56}
-                height={56}
-                src={item.image}
-                alt="같은옷"
-              />
-              <div className="filterItemTrue">
-                <Title2>{item.category}</Title2>
-                <Body3>{item.name}</Body3>
-              </div>
-            </S.FilterItem>
-          );
-        })}
+        {sameClothData &&
+          sameClothData.map((item, index) => {
+            return (
+              <S.FilterItem
+                onTouchMove={(e) => e.stopPropagation()}
+                key={index}
+                state={index === currentIndex}
+              >
+                <Image
+                  onClick={() => onClickImage(index)}
+                  width={56}
+                  height={56}
+                  src={item.clothes.imageUrl}
+                  alt="같은옷"
+                />
+                <div className="filterItemTrue">
+                  <Title2>{item.clothes.categoryType}</Title2>
+                  <Body3>{item.clothes.name}</Body3>
+                </div>
+              </S.FilterItem>
+            );
+          })}
       </S.Filter>
-      <S.List>
-        <img
-          src={
-            'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg'
-          }
-          alt=""
-        />
-        <div className="flexList">
-          <img
-            src={
-              'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg'
-            }
-            alt=""
-          />
-          <img
-            src={
-              'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg'
-            }
-            alt=""
-          />
-          <img
-            src={
-              'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg'
-            }
-            alt=""
-          />
-        </div>
-      </S.List>
+
+      {sameClothData && (
+        <S.List>
+          {sameClothData[currentIndex].ootdImages[0] && (
+            <S.FirstImage>
+              <NextImage
+                fill={true}
+                src={sameClothData[currentIndex].ootdImages[0].imageUrl}
+                alt=""
+                onClick={() =>
+                  onClickListImage(
+                    sameClothData[currentIndex].ootdImages[0].ootdId
+                  )
+                }
+              />
+            </S.FirstImage>
+          )}
+
+          <div className="flexList">
+            {sameClothData[currentIndex].ootdImages[1] && (
+              <S.FlexImage>
+                <NextImage
+                  fill={true}
+                  src={sameClothData[currentIndex].ootdImages[1].imageUrl}
+                  alt=""
+                  onClick={() =>
+                    onClickListImage(
+                      sameClothData[currentIndex].ootdImages[1].ootdId
+                    )
+                  }
+                />
+              </S.FlexImage>
+            )}
+            {sameClothData[currentIndex].ootdImages[2] && (
+              <S.FlexImage>
+                <NextImage
+                  fill={true}
+                  src={sameClothData[currentIndex].ootdImages[2].imageUrl}
+                  alt=""
+                  onClick={() =>
+                    onClickListImage(
+                      sameClothData[currentIndex].ootdImages[2].ootdId
+                    )
+                  }
+                />
+              </S.FlexImage>
+            )}
+            {sameClothData[currentIndex].ootdImages[3] && (
+              <S.FlexImage>
+                <NextImage
+                  fill={true}
+                  src={sameClothData[currentIndex].ootdImages[3].imageUrl}
+                  alt=""
+                  onClick={() =>
+                    onClickListImage(
+                      sameClothData[currentIndex].ootdImages[3].ootdId
+                    )
+                  }
+                />
+              </S.FlexImage>
+            )}
+          </div>
+        </S.List>
+      )}
       <Button
         size="big"
         backgroundColor="grey_100"

--- a/components/Domain/Main/SameCloth/style.tsx
+++ b/components/Domain/Main/SameCloth/style.tsx
@@ -41,6 +41,10 @@ const FilterItem = styled.div<FilterProps>`
     width: 100px;
   }
 
+  img {
+    object-fit: cover;
+  }
+
   h5 {
     color: ${(props) => props.theme.color.grey_00};
   }
@@ -72,24 +76,32 @@ const FilterItem = styled.div<FilterProps>`
 
 const List = styled.div`
   width: 100%;
-  img {
-    max-width: 350px;
-    max-height: 350px;
-    width: 100%;
-    object-fit: cover;
-    margin-top: 6px;
-  }
+  padding-right: 20px;
+  margin-bottom: 28px;
 
   .flexList {
+    margin-top: 6px;
     display: flex;
     gap: 6px;
-    max-width: 113px;
-    max-height: 113px;
-    width: 32%;
+    width: 100%;
+    position: relative;
   }
-  margin-bottom: 28px;
 `;
 
-const S = { Layout, Label, Filter, List, FilterItem };
+const FirstImage = styled.div`
+  width: 100%;
+  height: 0;
+  position: relative;
+  padding-bottom: 100%;
+`;
+
+const FlexImage = styled.div`
+  width: 32%;
+  height: 0;
+  padding-bottom: 32%;
+  position: relative;
+`;
+
+const S = { Layout, Label, Filter, List, FilterItem, FirstImage, FlexImage };
 
 export default S;

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,11 @@ const nextConfig = {
         destination: '/splash-screen',
         permanent: true,
       },
+      {
+        source: '/main',
+        destination: '/main/curation',
+        permanent: true,
+      },
     ]
   },
   reactStrictMode: false,

--- a/pages/main/[...main].tsx
+++ b/pages/main/[...main].tsx
@@ -130,6 +130,14 @@ export default function Main() {
   const [isExistNotReadAlarm, setIsExistNotReadAlarm] =
     useState<Boolean>(false);
   const { getExistIsNotReadAlarm } = AlarmApi();
+  const [mainInitialIndex, setMainInitialIndex] = useState<number>(1);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (router.query.main![0] === 'explore') {
+      setMainInitialIndex(2);
+    }
+  }, [router.isReady]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -150,28 +158,28 @@ export default function Main() {
           </div>
         }
       />
-      <TabView>
-        <TabView.TabBar
-          display="inline"
-          tab={['큐레이팅', '탐색']}
-          className="tabBar"
-        />
-        <TabView.Tabs>
-          <TabView.Tab>
-            <S.Curation>
-              {/* <TodayRecommend data={TodayRecommendSampleData} /> */}
-              <LikeOOTD />
-              <SameCloth data={SameClothDifferentFeeling} />
-              {/* <button onClick={onClickButton}>클릭해봐</button> */}
-            </S.Curation>
-          </TabView.Tab>
-          <TabView.Tab>
-            <S.Explore>
-              <Explore />
-            </S.Explore>
-          </TabView.Tab>
-        </TabView.Tabs>
-      </TabView>
+      {router.isReady && (
+        <TabView initialIndex={router.query.main![0] === 'explore' ? 2 : 1}>
+          <TabView.TabBar
+            display="inline"
+            tab={['큐레이팅', '탐색']}
+            className="tabBar"
+          />
+          <TabView.Tabs>
+            <TabView.Tab>
+              <S.Curation>
+                <LikeOOTD />
+                <SameCloth data={SameClothDifferentFeeling} />
+              </S.Curation>
+            </TabView.Tab>
+            <TabView.Tab>
+              <S.Explore>
+                <Explore />
+              </S.Explore>
+            </TabView.Tab>
+          </TabView.Tabs>
+        </TabView>
+      )}
     </S.Layout>
   );
 }

--- a/pages/main/[...main].tsx
+++ b/pages/main/[...main].tsx
@@ -9,135 +9,11 @@ import TabView from '@/components/TabView';
 import LikeOOTD from '@/components/Domain/Main/LikeOOTD';
 import Explore from '@/components/Domain/Main/Explore';
 
-const TodayRecommendSampleData = [
-  {
-    ootdImage:
-      'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
-    item: [
-      {
-        clothId: 0,
-        itemImage:
-          'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
-        caption: '태그',
-        brand: 'Nike',
-        category: '반소매',
-        name: 'Nike half sleeve logo T-shirt',
-        size: 'Size L',
-      },
-      {
-        clothId: 1,
-        itemImage:
-          'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
-        caption: '비슷한',
-        brand: 'Ader error',
-        category: '반소매',
-        name: 'Graphic half sleeve T-shirt',
-        size: 'Size XL',
-      },
-    ],
-  },
-  {
-    ootdImage:
-      'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    item: [
-      {
-        clothId: 1,
-        itemImage:
-          'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
-        caption: '태그',
-        brand: 'Nike',
-        category: 'Top',
-        name: '나이키 상의',
-        size: 'Body4',
-        icon: 'like',
-      },
-      {
-        clothId: 1,
-        itemImage:
-          'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
-        caption: '비슷한',
-        brand: 'Nike',
-        category: 'Top',
-        name: 'Body4',
-        size: 'Body4',
-        icon: 'like',
-      },
-    ],
-  },
-];
-
-const SameClothDifferentFeeling = [
-  {
-    clothid: 0,
-    image:
-      'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    category: '카테고리',
-    name: '제품명',
-  },
-  {
-    clothid: 0,
-    image:
-      'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    category: '카테고리',
-    name: '제품명',
-  },
-  {
-    clothid: 0,
-    image:
-      'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
-    category: '카테고리',
-    name: '제품명',
-  },
-  {
-    clothid: 0,
-    image:
-      'https://image.msscdn.net/mfile_s01/_shopstaff/list.staff_6515b944a6206.jpg',
-    category: '카테고리',
-    name: '제품명',
-  },
-  {
-    clothid: 0,
-    image:
-      'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
-    category: '카테고리',
-    name: '제품명',
-  },
-  {
-    clothid: 0,
-    image:
-      'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
-    category: '카테고리',
-    name: '제품명',
-  },
-  {
-    clothid: 0,
-    image:
-      'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
-    category: '카테고리',
-    name: '제품명',
-  },
-  {
-    clothid: 0,
-    image:
-      'https://image.msscdn.net/images/style/list/l_3_2023080717404200000013917.jpg',
-    category: '카테고리',
-    name: '제품명',
-  },
-];
-
 export default function Main() {
   const router = useRouter();
   const [isExistNotReadAlarm, setIsExistNotReadAlarm] =
     useState<Boolean>(false);
   const { getExistIsNotReadAlarm } = AlarmApi();
-  const [mainInitialIndex, setMainInitialIndex] = useState<number>(1);
-
-  useEffect(() => {
-    if (!router.isReady) return;
-    if (router.query.main![0] === 'explore') {
-      setMainInitialIndex(2);
-    }
-  }, [router.isReady]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -169,7 +45,7 @@ export default function Main() {
             <TabView.Tab>
               <S.Curation>
                 <LikeOOTD />
-                <SameCloth data={SameClothDifferentFeeling} />
+                <SameCloth />
               </S.Curation>
             </TabView.Tab>
             <TabView.Tab>

--- a/pages/ootd/[...OOTDNumber].tsx
+++ b/pages/ootd/[...OOTDNumber].tsx
@@ -90,6 +90,16 @@ const OOTD: ComponentWithLayout = () => {
   const [reRender, setReRender] = useState(0);
   const [getPostReRender, setGetPostReRender] = useState(0);
 
+  const onClickBackButton = () => {
+    if (router.query.OOTDNumber![1] === 'explore') {
+      router.push('/main/explore');
+    } else if (router.query.OOTDNumber![1] === 'curation') {
+      router.push('/main/curation');
+    } else {
+      router.back();
+    }
+  };
+
   useEffect(() => {
     const fetchData = async () => {
       if (!router.isReady) return;
@@ -148,7 +158,7 @@ const OOTD: ComponentWithLayout = () => {
   return (
     <S.Layout>
       <AppBar
-        leftProps={<AiOutlineArrowLeft onClick={() => router.back()} />}
+        leftProps={<AiOutlineArrowLeft onClick={onClickBackButton} />}
         middleProps={<></>}
         rightProps={<></>}
       />


### PR DESCRIPTION
# 🔢 이슈 번호

- close #311 

## ⚙ 작업 사항

- [x] `같은 옷 다른 느낌` api 연동 
- [x] 메인페이지 초기 렌더링 설정 
    - `/main/curation` : 큐레이션 페이지
    - `/main/explore` : 탐색 페이지 

## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/ecf78000-04a6-4ba7-bb1b-a00ba2d2f504)
