### PR TITLE
jwt 리프레시토큰 핸들링 로직 적용

### DIFF
--- a/apis/_api/auth.ts
+++ b/apis/_api/auth.ts
@@ -2,6 +2,7 @@ import fetcher from '../fetcher';
 import { NEXT_PUBLIC_DOMAIN_HOST } from '@/constants/develop.constants';
 import { postRegistUserInfoPayload } from './type';
 import { QueryParams } from '@/pages/sign-in/[...callback]';
+import { getCookie } from '@/utils/Cookie';
 
 export const login = async (payload: QueryParams) => {
   const { data } = await fetcher.get(
@@ -43,4 +44,14 @@ export const getUserId = async () => {
   const { data } = await fetcher.get('/v1/user/id');
 
   return data;
+};
+
+export const getNewToken = async () => {
+  const requestData = new URLSearchParams();
+  requestData.append('grantType', 'refresh_token');
+  requestData.append('refreshToken', getCookie('refreshToken'));
+
+  const data = await fetcher.post(`v1/oauth/token`, requestData);
+
+  return data.data;
 };

--- a/apis/_service/auth.service.ts
+++ b/apis/_service/auth.service.ts
@@ -33,3 +33,9 @@ export const getUserId = async () => {
 
   return data;
 };
+
+export const getNewToken = async () => {
+  const data = await authApi.getNewToken();
+
+  return data;
+};

--- a/apis/domain/Public/PublicApi.tsx
+++ b/apis/domain/Public/PublicApi.tsx
@@ -1,4 +1,5 @@
 import { authService, userService } from '@/apis/_service';
+import { setCookie } from '@/utils/Cookie';
 
 export const PublicApi = () => {
   const follow = async (id: number) => {
@@ -16,9 +17,18 @@ export const PublicApi = () => {
 
     return result;
   };
+
+  const getNewToken = async () => {
+    const { accessToken, refreshToken } = await authService.getNewToken();
+
+    setCookie('accessToken', accessToken, { path: '/' });
+    setCookie('refreshToken', refreshToken, { path: '/' });
+  };
+
   return {
     follow,
     unFollow,
     getUserId,
+    getNewToken,
   } as const;
 };

--- a/apis/domain/SignIn/SignInApi.tsx
+++ b/apis/domain/SignIn/SignInApi.tsx
@@ -1,8 +1,6 @@
 import { authService } from '@/apis/_service';
 import { setCookie } from '@/utils/Cookie';
 import { sendReactNativeMessage } from '@/utils/reactNativeMessage';
-import { useRecoilState } from 'recoil';
-import { loginStates } from '@/utils/recoil/atom';
 import {
   NEXT_PUBLIC_APPLE_URI,
   NEXT_PUBLIC_KAKAO_URI,
@@ -11,7 +9,6 @@ import { useRouter } from 'next/router';
 import { QueryParams } from '@/pages/sign-in/[...callback]';
 
 export const SignInApi = () => {
-  const [loginState, setLogin] = useRecoilState(loginStates);
   const router = useRouter();
 
   // callback 페이지에서 사용하는  API
@@ -29,13 +26,15 @@ export const SignInApi = () => {
         path: '/',
         // 보안 설정은 배포 직전에 설정해주기
       });
+      setCookie('refreshToken', data.refreshToken, {
+        path: '/',
+        // 보안 설정은 배포 직전에 설정해주기
+      });
 
       sendReactNativeMessage({
         type: 'accessToken',
         payload: data.accessToken,
       });
-
-      setLogin(true);
 
       return true;
     }

--- a/apis/fetcher.ts
+++ b/apis/fetcher.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { NEXT_PUBLIC_API_HOST } from '@/constants/develop.constants';
 import { getCookie } from '@/utils/Cookie';
+import { PublicApi } from './domain/Public/PublicApi';
 
 const fetcher = axios.create({
   baseURL: NEXT_PUBLIC_API_HOST,
@@ -19,4 +20,17 @@ fetcher.interceptors.request.use((config) => {
   return config;
 });
 
+fetcher.interceptors.response.use(
+  (config) => {
+    return config;
+  },
+  async (error) => {
+    if (error.response.data.divisionCode === 'U002') {
+      const { getNewToken } = PublicApi();
+      await getNewToken();
+
+      return fetcher.request(error.config);
+    }
+  }
+);
 export default fetcher;

--- a/components/Gallery/index.tsx
+++ b/components/Gallery/index.tsx
@@ -14,6 +14,7 @@ import { storedImageKey } from '@/utils/recoil/atom';
 import Alert from '../Alert';
 import NextImage from '../NextImage';
 import { PublicApi } from '@/apis/domain/Public/PublicApi';
+import { getCookie } from '@/utils/Cookie';
 
 interface GalleryProps {
   imageAndTag: ImageWithTag | undefined;
@@ -60,6 +61,10 @@ const Gallery = ({
   const getToken = async () => {
     const { getNewToken } = PublicApi();
     await getNewToken();
+    sendReactNativeMessage({
+      type: 'accessToken',
+      payload: getCookie('accessToken'),
+    });
   };
 
   useEffect(() => {

--- a/components/Gallery/index.tsx
+++ b/components/Gallery/index.tsx
@@ -13,6 +13,7 @@ import { useRecoilState } from 'recoil';
 import { storedImageKey } from '@/utils/recoil/atom';
 import Alert from '../Alert';
 import NextImage from '../NextImage';
+import { PublicApi } from '@/apis/domain/Public/PublicApi';
 
 interface GalleryProps {
   imageAndTag: ImageWithTag | undefined;
@@ -56,7 +57,13 @@ const Gallery = ({
     setIsOpenStoredImageAlert(false);
   };
 
+  const getToken = async () => {
+    const { getNewToken } = PublicApi();
+    await getNewToken();
+  };
+
   useEffect(() => {
+    getToken();
     if (storedImage !== undefined && item === 'OOTD') {
       setIsOpenStoredImageAlert(true);
     } else {

--- a/utils/recoil/atom.tsx
+++ b/utils/recoil/atom.tsx
@@ -4,16 +4,6 @@ import { recoilPersist } from 'recoil-persist';
 
 const { persistAtom } = recoilPersist();
 
-export const loginStates = atom<boolean>({
-  key: 'loginState',
-  default: false,
-});
-
-export const userNames = atom<string>({
-  key: 'userNames',
-  default: '',
-});
-
 export const storedImageKey = atom<ImageWithTag | undefined>({
   key: 'storedImageKey',
   default: undefined,


### PR DESCRIPTION
# 🔢 이슈 번호

- close #313 

## ⚙ 작업 사항

- [x] jwt 리프레시토큰 핸들링 로직 적용

[인터셉터를 활용한 에러 핸들링]
`interceptor.response.use()`를 활용해 **divisionCode**가 `U002`인 에러의 경우 토큰을 재 발급하고,
이전의 요청을 다시 보내도록 설정했습니다.

[react-native의 액세스 토큰 만료]
`Gallery` 페이지 진입 시 토큰을 재 발급 하도록 해 만료 가능성을 없앴습니다. 

## 📃 참고자료

- https://minhyeong-jang.github.io/2020/01/08/js-axios-interceptors-error

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/22f30107-c568-419d-9877-1ea7a7efe7ce)
