### PR TITLE
만료된 accessToken 전송 시 오류가 나는 버그 수정

### DIFF
--- a/apis/_api/auth.ts
+++ b/apis/_api/auth.ts
@@ -1,8 +1,12 @@
 import fetcher from '../fetcher';
-import { NEXT_PUBLIC_DOMAIN_HOST } from '@/constants/develop.constants';
+import {
+  NEXT_PUBLIC_API_HOST,
+  NEXT_PUBLIC_DOMAIN_HOST,
+} from '@/constants/develop.constants';
 import { postRegistUserInfoPayload } from './type';
 import { QueryParams } from '@/pages/sign-in/[...callback]';
 import { getCookie } from '@/utils/Cookie';
+import axios from 'axios';
 
 export const login = async (payload: QueryParams) => {
   const { data } = await fetcher.get(
@@ -51,7 +55,10 @@ export const getNewToken = async () => {
   requestData.append('grantType', 'refresh_token');
   requestData.append('refreshToken', getCookie('refreshToken'));
 
-  const data = await fetcher.post(`v1/oauth/token`, requestData);
+  const { data } = await axios.post(
+    `${NEXT_PUBLIC_API_HOST}/v1/oauth/token`,
+    requestData
+  );
 
-  return data.data;
+  return data;
 };


### PR DESCRIPTION
# 🔢 이슈 번호

- close #341 

## ⚙ 작업 사항

- [x] 만료된 accessToken 전송 시 오류가 나는 버그 수정
   - `getToken` api 에는 **accessToken**을 담지 않기로 함 

## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/2c5b5a61-5345-46b9-8717-ed33f8dd8cf4)
