### PR TITLE
앱 자동 로그인 추가

### DIFF
--- a/apis/domain/Public/PublicApi.tsx
+++ b/apis/domain/Public/PublicApi.tsx
@@ -1,4 +1,5 @@
 import { authService, userService } from '@/apis/_service';
+import { sendReactNativeMessage } from '@/utils/reactNativeMessage';
 export const PublicApi = () => {
   const follow = async (id: number) => {
     const data = await userService.follow(id);
@@ -25,6 +26,8 @@ export const PublicApi = () => {
 
     localStorage.setItem('accessToken', accessToken);
     localStorage.setItem('refreshToken', refreshToken);
+    sendReactNativeMessage({ type: 'accessToken', payload: accessToken });
+    sendReactNativeMessage({ type: 'refreshToken', payload: refreshToken });
   };
 
   return {

--- a/apis/domain/SignIn/SignInApi.tsx
+++ b/apis/domain/SignIn/SignInApi.tsx
@@ -29,6 +29,10 @@ export const SignInApi = () => {
         payload: data.accessToken,
       });
 
+      sendReactNativeMessage({
+        type: 'refreshToken',
+        payload: data.refreshToken,
+      });
       return true;
     }
   };

--- a/apis/domain/User/UserApi.tsx
+++ b/apis/domain/User/UserApi.tsx
@@ -4,6 +4,7 @@ import {
   putStylePayload,
 } from '@/apis/_api/type';
 import { authService, userService } from '@/apis/_service';
+import { sendReactNativeMessage } from '@/utils/reactNativeMessage';
 
 export const UserApi = () => {
   // 사용자 프로필 정보 조회
@@ -134,7 +135,7 @@ export const UserApi = () => {
 
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
-
+      sendReactNativeMessage({ type: 'logout' });
       if (status === 200) return true;
       return false;
     } catch (err) {
@@ -142,7 +143,7 @@ export const UserApi = () => {
       console.log('에러명:', err);
     }
   };
-  
+
   // 소셜 로그인 플랫폼 조회
   const getSocilLoginProvider = async () => {
     try {

--- a/components/Gallery/index.tsx
+++ b/components/Gallery/index.tsx
@@ -13,8 +13,8 @@ import { useRecoilState } from 'recoil';
 import { storedImageKey } from '@/utils/recoil/atom';
 import Alert from '../Alert';
 import NextImage from '../NextImage';
-import { PublicApi } from '@/apis/domain/Public/PublicApi'; 
-import Background from '../Background'; 
+import { PublicApi } from '@/apis/domain/Public/PublicApi';
+import Background from '../Background';
 
 interface GalleryProps {
   imageAndTag: ImageWithTag | undefined;
@@ -64,6 +64,10 @@ const Gallery = ({
     sendReactNativeMessage({
       type: 'accessToken',
       payload: localStorage.getItem('accessToken'),
+    });
+    sendReactNativeMessage({
+      type: 'refreshToken',
+      payload: localStorage.getItem('refreshToken'),
     });
   };
 

--- a/pages/sign-in/[...callback].tsx
+++ b/pages/sign-in/[...callback].tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { SignInApi } from '@/apis/domain/SignIn/SignInApi';
 import { RegisterApi } from '@/apis/domain/Register/RegisterApi';
+import Spinner from '@/components/Spinner';
 
 export interface QueryParams {
   code?: string;
@@ -41,5 +42,5 @@ export default function SignUpCallbackPage() {
     fetchData();
   }, [code, !router.isReady]);
 
-  return <div>loading</div>;
+  return <Spinner />;
 }

--- a/pages/splash-screen/index.tsx
+++ b/pages/splash-screen/index.tsx
@@ -2,19 +2,22 @@ import { ComponentWithLayout } from '../sign-up';
 import S from '@/pageStyle/splash-screen/style';
 import SplashLogo from '@/public/images/SplashLogo.svg';
 import { AppLayoutProps } from '@/AppLayout';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { PublicApi } from '@/apis/domain/Public/PublicApi';
 import { useSetRecoilState } from 'recoil';
 import { userId } from '@/utils/recoil/atom';
+import { getReactNativeMessage } from '@/utils/reactNativeMessage';
 
 const SplashScreen: ComponentWithLayout = () => {
   const router = useRouter();
   const { getUserId } = PublicApi();
   const setUserId = useSetRecoilState(userId);
+  const [_state, setState] = useState();
 
   useEffect(() => {
     const timer = setTimeout(async () => {
+      getReactNativeMessage(setState);
       if (localStorage.getItem('accessToken')) {
         const result = await getUserId();
         router.push('/main');

--- a/pages/splash-screen/index.tsx
+++ b/pages/splash-screen/index.tsx
@@ -8,20 +8,26 @@ import { PublicApi } from '@/apis/domain/Public/PublicApi';
 import { useSetRecoilState } from 'recoil';
 import { userId } from '@/utils/recoil/atom';
 import { getReactNativeMessage } from '@/utils/reactNativeMessage';
+import { RegisterApi } from '@/apis/domain/Register/RegisterApi';
 
 const SplashScreen: ComponentWithLayout = () => {
   const router = useRouter();
   const { getUserId } = PublicApi();
   const setUserId = useSetRecoilState(userId);
   const [_state, setState] = useState();
+  const { getCheckCompleteRegistUserInfo } = RegisterApi();
 
   useEffect(() => {
     const timer = setTimeout(async () => {
       getReactNativeMessage(setState);
       if (localStorage.getItem('accessToken')) {
         const result = await getUserId();
-        router.push('/main');
-        setUserId(result);
+        if (await getCheckCompleteRegistUserInfo()) {
+          router.push('/main');
+          setUserId(result);
+          return;
+        }
+        router.replace('/sign-up');
         return;
       }
       router.push('/onboarding');

--- a/utils/reactNativeMessage.ts
+++ b/utils/reactNativeMessage.ts
@@ -48,6 +48,12 @@ export const getReactNativeMessage = (
         setState(false);
       }
     }
+    if (parsedData!.type === 'token') {
+      const accessToken = parsedData?.payload.accessToken;
+      const refreshToken = parsedData?.payload.refreshToken;
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', refreshToken);
+    }
   };
   if (window.ReactNativeWebView) {
     //android


### PR DESCRIPTION
# 🔢 이슈 번호

- close #381

## ⚙ 작업 사항

- [x] 앱을 종료하고 다시 진입하면 웹의 로컬 스토리지가 초기화 되는 이슈 발생
   - [x] react-native의 저장소를 통해 저장
- [x] 유저가 회원 정보 입력을 완료하지 않고 앱을 종료하는 경우 홈으로 가는 이슈 발생
   - [x] 스플래시 스크린에서 정보 입력 유무 확인 하는 로직 추가

## 📃 참고자료

-

## 📷 스크린샷
