### PR TITLE
북마크 svg 수정

### DIFF
--- a/components/BottomNavBar/index.tsx
+++ b/components/BottomNavBar/index.tsx
@@ -19,21 +19,42 @@ import { useRecoilValue } from 'recoil';
 import { userId } from '@/utils/recoil/atom';
 import FilledSquare from '@/public/images/FilledPlusSquare.svg';
 import Link from 'next/link';
+import Image from 'next/image';
 
 const icons = [
   <AiOutlineHome />,
   <AiOutlineSearch />,
   <AiOutlinePlusSquare />,
-  <BookmarkOutlined />,
+  <Image
+    src="/images/BookmarkOutlined.svg"
+    alt="BookmarkOutlined"
+    width={16}
+    height={16}
+  />,
   <AiOutlineUser />,
 ];
 
 const activeIcons = [
   <AiFillHome />,
-  <SearchFilled />,
+  <Image
+    src="/images/SearchFilled.svg"
+    alt="SearchFilled"
+    width={16}
+    height={16}
+  />,
   <FilledSquare />,
-  <BookmarkFilled />,
-  <UserFilled />,
+  <Image
+    src="/images/BookmarkFilled.svg"
+    alt="BookmarkFilled"
+    width={16}
+    height={16}
+  />,
+  <Image
+    src="/images/UserFilled.svg"
+    alt="UserFilled"
+    width={16}
+    height={16}
+  />,
 ];
 
 interface BottomNavBarProps {

--- a/components/BottomNavBar/index.tsx
+++ b/components/BottomNavBar/index.tsx
@@ -19,42 +19,21 @@ import { useRecoilValue } from 'recoil';
 import { userId } from '@/utils/recoil/atom';
 import FilledSquare from '@/public/images/FilledPlusSquare.svg';
 import Link from 'next/link';
-import Image from 'next/image';
 
 const icons = [
   <AiOutlineHome />,
   <AiOutlineSearch />,
   <AiOutlinePlusSquare />,
-  <Image
-    src="/images/BookmarkOutlined.svg"
-    alt="BookmarkOutlined"
-    width={16}
-    height={16}
-  />,
+  <BookmarkOutlined />,
   <AiOutlineUser />,
 ];
 
 const activeIcons = [
   <AiFillHome />,
-  <Image
-    src="/images/SearchFilled.svg"
-    alt="SearchFilled"
-    width={16}
-    height={16}
-  />,
+  <SearchFilled />,
   <FilledSquare />,
-  <Image
-    src="/images/BookmarkFilled.svg"
-    alt="BookmarkFilled"
-    width={16}
-    height={16}
-  />,
-  <Image
-    src="/images/UserFilled.svg"
-    alt="UserFilled"
-    width={16}
-    height={16}
-  />,
+  <BookmarkFilled />,
+  <UserFilled />,
 ];
 
 interface BottomNavBarProps {

--- a/pages/mypage/[...UserId].tsx
+++ b/pages/mypage/[...UserId].tsx
@@ -52,7 +52,7 @@ export default function MyPage() {
     };
 
     ferchData();
-  }, [router.isReady, router.query.userId]);
+  }, [router.isReady, router.query.UserId![0]]);
 
   useEffect(() => {
     if (router.query.state !== '') {

--- a/pages/mypage/[...UserId].tsx
+++ b/pages/mypage/[...UserId].tsx
@@ -52,7 +52,7 @@ export default function MyPage() {
     };
 
     ferchData();
-  }, [router.isReady, router.query.UserId![0]]);
+  }, [getMypage, router.isReady, router.query.UserId]);
 
   useEffect(() => {
     if (router.query.state !== '') {


### PR DESCRIPTION
# 🔢 이슈 번호

- close #386

## ⚙ 작업 사항

- [ ] 북마크 svg 수정
import 후 화면 렌더링 되기 전에 이미지 크기가 svg와 icons의 차이
svg 이미지 import 하는 것 자체를 `Image` 태그에 직접 호출
대부분의 아이콘은 약 16px 정도이기에 Image 태그에서도 16px로 셋팅 후
화면 렌더링 후에 24px로 일관성 bottomNavBar 구성

## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/64068511/5610055d-f786-4945-9ae9-c72f180f0f2b)
![image](https://github.com/ootd-zip/client/assets/64068511/86da052d-e027-4c2e-9673-ad4a888737f8)

