### PR TITLE
ootd 상세 페이지 관련 수정

### DIFF
--- a/components/Comment/style.tsx
+++ b/components/Comment/style.tsx
@@ -43,9 +43,11 @@ const UserComment = styled.div`
     margin-right: 4px;
   }
   white-space: pre-line;
-  display: flex;
   color: ${(props) => props.theme.color.grey_30};
   padding: 2px 0 16px 0;
+  p {
+    display: inline;
+  }
 `;
 const CommentCommunication = styled.div`
   display: flex;

--- a/components/Domain/OOTD/UserCloth/index.tsx
+++ b/components/Domain/OOTD/UserCloth/index.tsx
@@ -73,7 +73,7 @@ export default function UserCloth({ userName, userId }: UserClothProps) {
                     {data[index + 1] && (
                       <ClothInformation
                         onClick={() =>
-                          router.push(`cloth/${data[index + 1].id}`)
+                          router.push(`/cloth/${data[index + 1].id}`)
                         }
                         clothId={data[index + 1].id}
                         clothImage={data[index + 1].imageUrl}


### PR DESCRIPTION
# 🔢 이슈 번호

- close #389 

## ⚙ 작업 사항

- [x] ootd 상세 페이지 유저의 옷장 탭 관련 라우팅 수정
- [x] 댓글이 길 때 태그가 깨지는 현상 수정

## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/2b0732c0-c533-4d94-b8c2-371d008132a9)
