### PR TITLE
이미지 로딩중 띄울 블러 이미지 추가

### DIFF
--- a/components/NextImage/index.tsx
+++ b/components/NextImage/index.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import { MutableRefObject } from 'react';
-
 interface ImageProps {
   src: string;
   alt: string;
@@ -33,6 +32,8 @@ export default function NextImage({
       width={width}
       height={height}
       ref={ref}
+      placeholder="blur"
+      blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=="
     />
   );
 }

--- a/components/UI/ImageWithCaption/index.tsx
+++ b/components/UI/ImageWithCaption/index.tsx
@@ -1,12 +1,12 @@
 import { ImageProps } from '@/components/Card/type';
 import { ImageCaption, ImageFigure } from './style';
-import Image from 'next/image';
 import { Caption2 } from '../TypoGraphy';
+import NextImage from '@/components/NextImage';
 
 export default function ImageWithCaption(props: ImageProps) {
   return (
     <ImageFigure size={props.size}>
-      <Image onClick={props.onClick} src={props.src} alt={props.alt} fill />
+      <NextImage onClick={props.onClick} src={props.src} alt={props.alt} fill />
       {props.caption !== '' && (
         <ImageCaption size={props.size}>
           <Caption2 className="caption">{props.caption}</Caption2>


### PR DESCRIPTION
# 🔢 이슈 번호

- close #410

## ⚙ 작업 사항

- [x] 이미지 로딩중 띄울 블러 이미지 추가

## 📃 참고자료

- https://velog.io/@sangbooom/next.js-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%8A%A4%EC%BC%88%EB%A0%88%ED%86%A4-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/551063de-b0b9-44b8-bd6e-0434328ef179)
![image](https://github.com/ootd-zip/client/assets/158991486/82b55ac3-2163-4b64-b857-c2f8452c3c44)
