### PR TITLE
메인 페이지 기본 컨텐츠 변경

### DIFF
--- a/components/BottomNavBar/index.tsx
+++ b/components/BottomNavBar/index.tsx
@@ -56,7 +56,7 @@ export default function BottomNavBar({
   const myId = useRecoilValue(userId);
 
   const routes = [
-    '/main/curation',
+    '/main/explore',
     '/search',
     '/plus',
     '/bookmark',

--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ const nextConfig = {
       },
       {
         source: '/main',
-        destination: '/main/curation',
+        destination: '/main/explore',
         permanent: true,
       },
     ]

--- a/pages/mypage/[...UserId].tsx
+++ b/pages/mypage/[...UserId].tsx
@@ -76,13 +76,13 @@ export default function MyPage() {
         if (router.query.UserId![1] === 'search') {
           router.push(`/search?block=false`);
         } else {
-          router.push(`/main/curation?block=false}`);
+          router.push(`/main/explore?block=false}`);
         }
       } else if (blockUser === '성공') {
         if (router.query.UserId![1] === 'search') {
           router.push(`/search?block=true`);
         } else {
-          router.push(`/main/curation?block=true`);
+          router.push(`/main/explore?block=true`);
         }
       }
     }


### PR DESCRIPTION
# 🔢 이슈 번호

- close #431 

## ⚙ 작업 사항

- [x] 메인 페이지 기본 컨텐츠 변경 (큐레티잉 -> 탐색)
     - 서비스 초기에는 아이템이 없기때문에 탐색을 디폴트로 하는게 좋을 것 같다는 판단
 

## 📃 참고자료

-

## 📷 스크린샷
