### PR TITLE
팔로우 팔로잉 페이지 인원이 제대로 표시 되지 않는 이슈 

### DIFF
--- a/components/Domain/FollowList/Follower/index.tsx
+++ b/components/Domain/FollowList/Follower/index.tsx
@@ -66,7 +66,7 @@ export default function Follower({
     useInfiniteScroll({
       fetchDataFunction,
       initialData: [],
-      size: 6,
+      size: 20,
     });
 
   useEffect(() => {
@@ -87,7 +87,7 @@ export default function Follower({
   };
 
   useEffect(() => {
-    if (keyword.length > 0) reset();
+    reset();
   }, [keyword]);
 
   useEffect(() => {

--- a/components/Domain/FollowList/Following/index.tsx
+++ b/components/Domain/FollowList/Following/index.tsx
@@ -58,7 +58,7 @@ export default function Following({
     useInfiniteScroll({
       fetchDataFunction,
       initialData: [],
-      size: 7,
+      size: 20,
     });
 
   useEffect(() => {
@@ -74,7 +74,7 @@ export default function Following({
   }, [data]);
 
   useEffect(() => {
-    if (keyword.length > 0) reset();
+    reset();
   }, [keyword]);
 
   useEffect(() => {


### PR DESCRIPTION
# 🔢 이슈 번호

- close #442 

## ⚙ 작업 사항

- [x] 팔로우 팔로잉 페이지 인원이 제대로 표시 되지 않는 이슈 해결
- [x] 검색어가 없을때도 검색하도록 수정  

## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/f9d5127f-84b9-424a-a47e-d98e590ba21f)
![image](https://github.com/ootd-zip/client/assets/158991486/f9d5127f-84b9-424a-a47e-d98e590ba21f)
