### PR TITLE
댓글 작성 시 댓글 리스트 프로필 이미지 깜빡거림 이슈 해결

### DIFF
--- a/components/PostingComment/index.tsx
+++ b/components/PostingComment/index.tsx
@@ -2,6 +2,7 @@ import React, {
   Dispatch,
   MutableRefObject,
   SetStateAction,
+  useCallback,
   useEffect,
   useState,
 } from 'react';
@@ -35,7 +36,6 @@ interface PostingCommentProps {
   setReRender: Dispatch<SetStateAction<number>>;
   setComment: Dispatch<SetStateAction<CommentStateType>>;
   commentRef: MutableRefObject<any>;
-  comment: CommentStateType;
   setCommentWriting: Dispatch<SetStateAction<Boolean>>;
   declaration: Boolean;
   setDeclaration: Dispatch<SetStateAction<Boolean>>;
@@ -45,12 +45,11 @@ interface PostingCommentProps {
   setBlockStatus: Dispatch<SetStateAction<Boolean>>;
 }
 
-export default function PostingComment({
+function PostingComment({
   reRender,
   setReRender,
   setComment,
   commentRef,
-  comment,
   setCommentWriting,
   declaration,
   setDeclaration,
@@ -108,11 +107,13 @@ export default function PostingComment({
   }, [router.isReady, reRender, router.query.OOTDNumber]);
 
   const onClickReplyButton = (userName: string, commentId: number) => {
-    setComment({
-      ...comment,
-      taggedUserName: userName,
-      parentDepth: 1,
-      commentParentId: commentId,
+    setComment((previous) => {
+      return {
+        ...previous,
+        taggedUserName: userName,
+        parentDepth: 1,
+        commentParentId: commentId,
+      };
     });
     setCommentWriting(true);
     commentRef.current.focus();
@@ -259,3 +260,5 @@ export default function PostingComment({
   }
   return <>{commentType === 'preview' ? <ComentPreview /> : <ComentAll />}</>;
 }
+
+export default React.memo(PostingComment);

--- a/pages/ootd/[...OOTDNumber].tsx
+++ b/pages/ootd/[...OOTDNumber].tsx
@@ -210,7 +210,6 @@ const OOTD: ComponentWithLayout = () => {
           setDeclaration={setDeclaration}
           receivedDeclaration={receivedDeclaration}
           setReceivedDeclaration={setReceivedDeclaration}
-          comment={comment}
           setComment={setComment}
           commentRef={commentRef}
           setCommentWriting={setCommentWriting}


### PR DESCRIPTION
# 🔢 이슈 번호

- close #446 

## ⚙ 작업 사항

- [x] 댓글 작성 시 댓글 리스트 프로필 이미지 깜빡거림 이슈 해결
   - 작성중인 댓글인 `comment`가 `PostingComment`의 **props**로 전달되다보니 comment가 변경될 때마다 `PostingComment`가 리렌더링 되고 있었습니다.
   - 이에 저는 `comment`를 넘기지 않고 `setComment`의 **previous**값을 이용해 상태를 업데이트 하고 
   - `PostingComment`에 **React.memo**를 적용해 리렌더링을 방지했습니다.

## 📃 참고자료

-

## 📷 스크린샷
