### PR TITLE
옷 상세 페이지 구매 링크 이동

### DIFF
--- a/components/DetailCloth/DetailClothDiscription/index.tsx
+++ b/components/DetailCloth/DetailClothDiscription/index.tsx
@@ -14,6 +14,11 @@ interface ClothDiscriptionProps {
   memo?: string;
 }
 
+import {
+  getReactNativeMessage,
+  sendReactNativeMessage,
+} from '@/utils/reactNativeMessage';
+
 export default function DetailClothDiscription({
   isLink,
   purchasing,
@@ -21,7 +26,8 @@ export default function DetailClothDiscription({
   memo,
 }: ClothDiscriptionProps) {
   const clickedLink = (linkItem: string) => {
-    window.open(`${linkItem}`);
+    // window.open(`${linkItem}`);
+    sendReactNativeMessage({ type: 'clickedPurchaseLink', payload: linkItem });
   };
   return (
     <S.Layout>

--- a/components/DetailCloth/DetailClothDiscription/index.tsx
+++ b/components/DetailCloth/DetailClothDiscription/index.tsx
@@ -20,6 +20,9 @@ export default function DetailClothDiscription({
   uploadDate,
   memo,
 }: ClothDiscriptionProps) {
+  const clickedLink = (linkItem: string) => {
+    window.open(`https://${linkItem}`);
+  };
   return (
     <S.Layout>
       <S.Category>
@@ -31,7 +34,11 @@ export default function DetailClothDiscription({
           )}
         </S.IconSpan>
         {isLink ? (
-          <Body3 state="underline" className="isLink">
+          <Body3
+            state="underline"
+            className="isLink"
+            onClick={() => clickedLink(purchasing)}
+          >
             {purchasing}
           </Body3>
         ) : (

--- a/components/DetailCloth/DetailClothDiscription/index.tsx
+++ b/components/DetailCloth/DetailClothDiscription/index.tsx
@@ -21,7 +21,7 @@ export default function DetailClothDiscription({
   memo,
 }: ClothDiscriptionProps) {
   const clickedLink = (linkItem: string) => {
-    window.open(`https://${linkItem}`);
+    window.open(`${linkItem}`);
   };
   return (
     <S.Layout>


### PR DESCRIPTION
# 🔢 이슈 번호

- close #433

## ⚙ 작업 사항

- [ ] 옷 상세 페이지 구매 링크 이동
(사용자가 등록한 링크를 기준으로 하기에 사용자가 잘못 올린 경우 404가 가능성 생각)

## 📃 참고자료

-

## 📷 스크린샷

![image](https://github.com/ootd-zip/client/assets/64068511/ec7ac2d0-1e55-4ba9-8730-ed32776d7bd5)
