### PR TITLE
옷, ootd 추가 관련 수정 

### DIFF
--- a/components/Domain/AddCloth/BrandModal/style.tsx
+++ b/components/Domain/AddCloth/BrandModal/style.tsx
@@ -64,6 +64,7 @@ const SelectedBrand = styled.div`
   }
   width: 100%;
   padding: 16px 20px;
+  border-top: 1px solid ${(props) => props.theme.color.grey_95};
 `;
 
 const SelectedBrandSpan = styled.div`
@@ -73,7 +74,6 @@ const SelectedBrandSpan = styled.div`
   background-color: ${(props) => props.theme.color.grey_10};
   color: ${(props) => props.theme.color.grey_100};
   border-radius: 17px;
-
   .close {
     color: ${(props) => props.theme.color.grey_100};
     position: absolute;

--- a/components/Domain/AddOOTD/StyleModal/index.tsx
+++ b/components/Domain/AddOOTD/StyleModal/index.tsx
@@ -78,7 +78,7 @@ export default function StyleModal({
           </S.CheckBox>
           <NextButton
             className="nextButton"
-            state={style !== null && style.length > 0}
+            state={!(currentStyle !== undefined && currentStyle.length === 0)}
             onClick={onClickStyleCompleteButton}
           >
             선택완료

--- a/components/Gallery/style.tsx
+++ b/components/Gallery/style.tsx
@@ -63,7 +63,7 @@ interface ImageNumberProps {
 const ImageNumber = styled.div<ImageNumberProps>`
   position: absolute;
   top: 4px;
-  right: 12px;
+  right: 8px;
   width: 20px;
   height: 20px;
   border-radius: 50%;

--- a/pageStyle/add-ootd/WriteOOTD/style.tsx
+++ b/pageStyle/add-ootd/WriteOOTD/style.tsx
@@ -18,7 +18,7 @@ const Layout = styled.div`
 
 const OOTDImage = styled.div`
   display: flex;
-  padding: 8px 0 48px 20px;
+  padding: 8px 0 40px 20px;
   gap: 8px;
   overflow-x: scroll;
   img {
@@ -44,7 +44,7 @@ const Style = styled.div`
   display: flex;
   align-items: center;
   position: relative;
-  margin: 32px 0 0 0;
+  margin: 16px 0 0 0;
 
   svg {
     position: absolute;

--- a/pages/add-cloth/BasicInfoFirst/index.tsx
+++ b/pages/add-cloth/BasicInfoFirst/index.tsx
@@ -77,7 +77,12 @@ export default function BasicInfoFirst({
   const Brand = <Body3>{clothBrand && clothBrand[0].name}</Body3>;
 
   const WhereToBuy = (
-    <Body3 style={{ WebkitTextDecorationLine: 'underline' }}>
+    <Body3
+      style={{
+        WebkitTextDecorationLine:
+          clothWhereBuy.type === 'Link' ? 'underline' : 'none',
+      }}
+    >
       {clothWhereBuy?.letter}
     </Body3>
   );

--- a/pages/add-cloth/BasicInfoFirst/index.tsx
+++ b/pages/add-cloth/BasicInfoFirst/index.tsx
@@ -76,7 +76,7 @@ export default function BasicInfoFirst({
 
   const Brand = <Body3>{clothBrand && clothBrand[0].name}</Body3>;
 
-  const WhereToBuy = (
+  const WhereToBuy = clothWhereBuy && (
     <Body3
       style={{
         WebkitTextDecorationLine:

--- a/pages/add-ootd/ClothTag/index.tsx
+++ b/pages/add-ootd/ClothTag/index.tsx
@@ -115,6 +115,8 @@ export default function ClothTag({
         slidesToShow={1}
         infinite={false}
         beforeChange={(_current: number, next: number) => setSlideIndex(next)}
+        dots={true}
+        initialSlide={0}
       >
         {imageAndTag?.map((item, ootdIndex) => {
           return (

--- a/pages/add-ootd/WriteOOTD/index.tsx
+++ b/pages/add-ootd/WriteOOTD/index.tsx
@@ -154,7 +154,7 @@ export default function WriteOOTD({
           state={complete}
           onClick={onClickSubmitButton}
         >
-          다음
+          작성 완료
         </NextButton>
       </S.Layout>
       {styleModalIsOpen && (

--- a/utils/reactNativeMessage.ts
+++ b/utils/reactNativeMessage.ts
@@ -8,7 +8,7 @@ interface Message {
 export const getReactNativeMessage = (
   setState: Dispatch<SetStateAction<any>>
 ) => {
-  const listener = (event: WebViewMessageEvent) => {
+  const listener = (event: any) => {
     const parsedData = JSON.parse(event.data);
     if (parsedData?.type === 'OOTD') {
       const banana = parsedData?.payload;


### PR DESCRIPTION
# 🔢 이슈 번호

- #470 

## ⚙ 작업 사항

- [x] 사진 선택 페이지 순서 버튼 상우 간격 수정
- [x] 구매처 직접 입력 선택 시 밑줄 제거
- [x] 브랜드 선택 시 chip 위 stroke 추가
- [x] 사이즈 선택 시 클릭한 영역 border 제거
- [x] ootd 게시하기 페이지 간격 수정
- [x] ootd 게시하기 버튼 라이팅 변경
- [x] ootd 스타일 태그 선택하지 않은 경우 버튼 상태 수정
- [x] 옷 태그 페이지 `Carousel` dots 추가


## 📃 참고자료

-

## 📷 스크린샷
