### PR TITLE
옷 상세보기 페이지 수정

### DIFF
--- a/components/Domain/OOTD/UserCloth/index.tsx
+++ b/components/Domain/OOTD/UserCloth/index.tsx
@@ -35,7 +35,7 @@ export default function UserCloth({ userName, userId }: UserClothProps) {
     return data;
   };
 
-  const { data: userClothData } = useInfiniteScroll({
+  const { data: userClothData, reset } = useInfiniteScroll({
     fetchDataFunction,
     initialData: [],
     size: 10,
@@ -44,6 +44,10 @@ export default function UserCloth({ userName, userId }: UserClothProps) {
   useEffect(() => {
     setData(userClothData);
   }, [userClothData]);
+
+  useEffect(() => {
+    reset();
+  }, [router.isReady, router.query.OOTDNumber![0], userId]);
 
   return (
     <S.Layout>

--- a/components/Domain/OOTD/UserCloth/style.tsx
+++ b/components/Domain/OOTD/UserCloth/style.tsx
@@ -3,7 +3,7 @@ import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 
 const Layout = styled.div`
-  padding: 0 20px;
+  padding: 0 0 0 20px;
 `;
 const Title = styled.div`
   display: flex;

--- a/components/Domain/OOTD/UserOtherOOTD/index.tsx
+++ b/components/Domain/OOTD/UserOtherOOTD/index.tsx
@@ -35,32 +35,32 @@ export default function UserOtherOOTD({ userId, userName }: UserOOTDProps) {
 
   const [data, setData] = useState<OOTDListType[] | null>(null);
 
+  if (!data || data.length === 0) return <></>;
+
   return (
     <S.Layout>
-      {data && (
-        <>
-          <S.Title>
-            <Title1>{userName}님의 다른 OOTD</Title1>
-          </S.Title>
-          <S.OOTD>
-            <Carousel infinite={false} slidesToShow={2.15} dots={false}>
-              {data.map((item) => {
-                return (
-                  <NextImage
-                    onClick={() => router.push(`/ootd/${item.id}`)}
-                    key={item.id}
-                    src={item.image}
-                    alt="이 유저의 다른 ootd"
-                    fill={false}
-                    width={167}
-                    height={167}
-                  />
-                );
-              })}
-            </Carousel>
-          </S.OOTD>
-        </>
-      )}
+      <>
+        <S.Title>
+          <Title1>{userName}님의 다른 OOTD</Title1>
+        </S.Title>
+        <S.OOTD>
+          <Carousel infinite={false} slidesToShow={2.15} dots={false}>
+            {data.map((item) => {
+              return (
+                <NextImage
+                  onClick={() => router.push(`/ootd/${item.id}`)}
+                  key={item.id}
+                  src={item.image}
+                  alt="이 유저의 다른 ootd"
+                  fill={false}
+                  width={167}
+                  height={167}
+                />
+              );
+            })}
+          </Carousel>
+        </S.OOTD>
+      </>
     </S.Layout>
   );
 }

--- a/components/Posting/index.tsx
+++ b/components/Posting/index.tsx
@@ -229,7 +229,12 @@ export default function Posting({
             onClick={() => setClothTagOpen(!clothTagOpen)}
             className="tag"
           />
-          <Carousel infinite={false} slidesToShow={1} dots={true}>
+          <Carousel
+            infinite={false}
+            slidesToShow={1}
+            dots={true}
+            initialSlide={0}
+          >
             {data.ootdImages?.map((item, index) => {
               return (
                 <S.ImageWithTag key={index}>


### PR DESCRIPTION
# 🔢 이슈 번호

- close #471 

## ⚙ 작업 사항

- [x] 이미지 최초 인덱스 추가
- [x] 유저의 옷장 컴포넌트 패딩 수정
- [x] 유저의 옷장 조회 api `dependency` 수정

## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/ootd-zip/client/assets/158991486/8c0777e0-a80f-458d-b590-0a63cdbbaf62)
![image](https://github.com/ootd-zip/client/assets/158991486/b03fa36e-9976-4670-8713-26b482abedde)
