### PR TITLE
태그한 유저의 휴대폰 크기보다 작은 휴대폰에서의 태그가 안보이는 버그

### DIFF
--- a/components/Posting/index.tsx
+++ b/components/Posting/index.tsx
@@ -250,16 +250,12 @@ export default function Posting({
                           key={index}
                           clothTagOpen={clothTagOpen}
                           xrate={String(
-                            Number(items.coordinate?.xrate) -
-                              Number(
-                                items.deviceSize?.deviceWidth - componentWidth
-                              )
+                            (Number(items.coordinate?.xrate) * componentWidth) /
+                              items.deviceSize?.deviceWidth
                           )}
                           yrate={String(
-                            Number(items.coordinate?.yrate) -
-                              Number(
-                                items.deviceSize?.deviceHeight - componentHeight
-                              )
+                            (Number(items.coordinate?.yrate) * componentWidth) /
+                              items.deviceSize?.deviceWidth
                           )}
                         >
                           <TagInformation


### PR DESCRIPTION
# 🔢 이슈 번호

- close #514 

## ⚙ 작업 사항

- [x] 태그 위치 계산 하는 방법 변경 
  - 기존의 계산법: `태그 위치 - (등록한 유저의 휴대폰 사이즈 - 게시물을 보는 유저의 휴대폰 사이즈)`
  - 새로운 계산법: `태그 위치 * (게시물을 보는 유저의 휴대폰 사이즈 / 등록한 유저의 휴대폰 사이즈)`


## 📃 참고자료

-

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/32d78bd4-bbb0-4fee-8242-a61d7718456a)
