### PR TITLE
인피니티 스크롤 시 아이템이 하나밖에 없을 경우 생기는 오류

### DIFF
--- a/hooks/useInfiniteScroll.tsx
+++ b/hooks/useInfiniteScroll.tsx
@@ -45,7 +45,7 @@ export default function useInfiniteScroll({
       setPage(1);
     } else {
       setData((prevData: any) => {
-        if (prevData.length > 1) return [...prevData, ...result.content];
+        if (prevData.length >= 1) return [...prevData, ...result.content];
         else return result.content;
       });
       setPage((prevPage) => prevPage + 1);


### PR DESCRIPTION
# 🔢 이슈 번호

- close #528 

## ⚙ 작업 사항

- [x] 조건을 변경

## 📃 참고자료

-

## 📷 스크린샷
