### PR TITLE
유저 인증 관련 로직 수정

### DIFF
--- a/apis/domain/Public/PublicApi.tsx
+++ b/apis/domain/Public/PublicApi.tsx
@@ -36,8 +36,7 @@ export default function PublicApi() {
     const { accessToken, refreshToken } = await authService
       .getNewToken()
       .catch((err) => {
-        window.location.replace('/sign-in');
-        localStorage.clear();
+        throw Error(err);
       });
 
     localStorage.setItem('accessToken', accessToken);

--- a/pages/sign-in/index.tsx
+++ b/pages/sign-in/index.tsx
@@ -5,11 +5,16 @@ import { ComponentWithLayout } from '../sign-up';
 import { SignInApi } from '@/apis/domain/SignIn/SignInApi';
 import SocialLoginButton from '@/components/Domain/SignIn/SocialLoginButton';
 import SplashLogo from '@/public/images/SplashLogo.svg';
+import { useEffect } from 'react';
 /*
 이름: 로그인 페이지
 */
 const SignIn: ComponentWithLayout = () => {
   const [, routing] = SignInApi();
+
+  useEffect(() => {
+    localStorage.clear();
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
# 🔢 이슈 번호

- #530 

## ⚙ 작업 사항

- [x] 유저 인증 실패 시 이전 요청에 헤더를 수정해 재 요청하는 로직 작성
- [x] 로그인 페이지 접근 시 로컬 스토리지를 비우는 과정 수행 

## 📃 참고자료

-

## 📷 스크린샷
