### PR TITLE
스크롤 관련 에러 수정

### DIFF
--- a/components/Domain/Search/SearchResult/Profile/index.tsx
+++ b/components/Domain/Search/SearchResult/Profile/index.tsx
@@ -13,6 +13,7 @@ import Button from '@/components/Button';
 import Avatar from '@/public/images/Avatar.svg';
 import NextImage from '@/components/NextImage';
 import PublicApi from '@/apis/domain/Public/PublicApi';
+import useRememberScroll from '@/hooks/useRememberScroll';
 
 export type ProfileListType = {
   id: number;
@@ -72,6 +73,14 @@ export default function Profile({
     // 미팔로우 중이라면 팔로우 API
     await follow(userId);
   };
+
+  // 검색 결과 스크롤 저장
+  useRememberScroll({
+    key: 'search-user',
+    containerRef: profileRef,
+    setList: setProfileList,
+    list: profileList,
+  });
 
   return (
     <>

--- a/components/Domain/Search/SearchResult/index.tsx
+++ b/components/Domain/Search/SearchResult/index.tsx
@@ -64,14 +64,6 @@ export default function SearchResult({ keywordsValue }: searchResultProps) {
     key: 'search-user',
   });
 
-  // 검색 결과 스크롤 저장
-  useRememberScroll({
-    key: 'search-user',
-    containerRef: profileRef,
-    setList: setProfileList,
-    list: profileList,
-  });
-
   useEffect(() => {
     if (!profileData || profileData.length === 0) return;
     setProfileList(

--- a/hooks/useInfiniteScroll.tsx
+++ b/hooks/useInfiniteScroll.tsx
@@ -66,7 +66,7 @@ export default function useInfiniteScroll({
     fetchData(page, size).then(() => setIsLoading(false));
   }, [isLoading, hasNextPage]);
 
-  const handleScroll = useCallback(() => {
+  const handleScroll = () => {
     const container = containerRef.current;
     if (!container) return;
 
@@ -75,7 +75,7 @@ export default function useInfiniteScroll({
     if (scrollTop + clientHeight >= scrollHeight - 20 && !isLoading) {
       setIsLoading(true);
     }
-  }, [isLoading]);
+  };
 
   useEffect(() => {
     const container = containerRef.current;


### PR DESCRIPTION
# 🔢 이슈 번호

- #532 

## ⚙ 작업 사항

- [x] 일부 페이지에서 스크롤 이벤트 감지가 되지 않는 버그 수정
- [x] 검색 페이지에서 프로필 페이지의 스크롤이 무한스크롤 할때마다 0으로 올라가는 버그 수정

## 📃 참고자료

- callback 함수로 감싸져있던 스크롤 함수의 callback을 제거했습니다. 
- useRememberScroll 훅의 위치를 SearchResult에서 Profile로 수정했습니다. 
   - SearchResult 컴포넌트가 리렌더링 될 때, 내부의 모든 요소들이 새로 그려집니다. 이 과정에서 일시적으로 스크롤 위치가 초기화될 수 있습니다. 그 직후 useEffectAfterMount가 실행되어 스크롤 위치를 복원하려 하지만, 타이밍 문제로 인해 사용자가 스크롤 점프를 경험할 수 있습니다.

## 📷 스크린샷
