### PR TITLE
 옷 등록 과정 중 브랜드 선택 완료 시 모달이 닫히지 않는 버그 수정

### DIFF
--- a/components/Domain/AddCloth/BrandModal/index.tsx
+++ b/components/Domain/AddCloth/BrandModal/index.tsx
@@ -66,6 +66,7 @@ export default function BrandModal({
       return;
     }
     setClothBrand(selectedBrandList);
+    setBrandModalIsOpen(false);
   };
 
   //키워드 변경 시 브랜드 조회 api 호출한 뒤 브랜드 리스트 업데이트


### PR DESCRIPTION
# 🔢 이슈 번호

- #538 

## ⚙ 작업 사항

- [x] 옷 등록 과정 중 브랜드 선택 완료 시 모달이 닫히지 않는 버그를 수정했습니다.

