### PR TITLE
무한 스크롤 관련 이슈 해결

### DIFF
--- a/apis/fetcher.ts
+++ b/apis/fetcher.ts
@@ -25,7 +25,7 @@ fetcher.interceptors.response.use(
     return config;
   },
   async (error) => {
-    if (error.respnse.data && error.response.data.divisionCode === 'U002') {
+    if (error.response.data.divisionCode === 'U002') {
       if (!refreshing) {
         // 리프레시 중이 아닌 경우에만 리프레시 요청 진행
         refreshing = true; // 리프레시 중으로 표시

--- a/apis/fetcher.ts
+++ b/apis/fetcher.ts
@@ -6,7 +6,6 @@ let refreshing = false; // 리프레시 중인지 여부를 추적하는 변수
 
 const fetcher = axios.create({
   baseURL: NEXT_PUBLIC_API_HOST,
-  timeout: 2500,
 });
 
 fetcher.interceptors.request.use((config) => {
@@ -26,7 +25,7 @@ fetcher.interceptors.response.use(
     return config;
   },
   async (error) => {
-    if (error.response.data.divisionCode === 'U002') {
+    if (error.respnse.data && error.response.data.divisionCode === 'U002') {
       if (!refreshing) {
         // 리프레시 중이 아닌 경우에만 리프레시 요청 진행
         refreshing = true; // 리프레시 중으로 표시

--- a/components/Domain/FollowList/Follower/index.tsx
+++ b/components/Domain/FollowList/Follower/index.tsx
@@ -13,6 +13,7 @@ import { useRecoilValue } from 'recoil';
 import { userId } from '@/utils/recoil/atom';
 import Spinner from '@/components/Spinner';
 import useEffectAfterMount from '@/hooks/useEffectAfterMount';
+import useRememberScroll from '@/hooks/useRememberScroll';
 
 interface followerProps {
   setSelectedUserName: Dispatch<SetStateAction<string>>;
@@ -84,6 +85,14 @@ export default function Follower({
     fetchDataFunction,
     initialData: [],
     size: 20,
+    key: `follower-${Number(router.query.UserId![0])}`,
+  });
+
+  useRememberScroll({
+    key: `follower-${Number(router.query.UserId![0])}`,
+    containerRef,
+    setList: setFollowerList,
+    list: followerList,
   });
 
   useEffect(() => {

--- a/components/Domain/FollowList/Follower/index.tsx
+++ b/components/Domain/FollowList/Follower/index.tsx
@@ -67,7 +67,7 @@ export default function Follower({
       page,
       size,
       name: keyword,
-      userId: Number(router.query.UserId![0]),
+      userId: Number(router.query.UserId ?? [0]),
     });
     return data;
   };
@@ -85,11 +85,11 @@ export default function Follower({
     fetchDataFunction,
     initialData: [],
     size: 20,
-    key: `follower-${Number(router.query.UserId![0])}`,
+    key: `follower-${Number(router.query.UserId ?? [0])}`,
   });
 
   useRememberScroll({
-    key: `follower-${Number(router.query.UserId![0])}`,
+    key: `follower-${Number(router.query.UserId ?? [0])}`,
     containerRef,
     setList: setFollowerList,
     list: followerList,

--- a/components/Domain/FollowList/Follower/index.tsx
+++ b/components/Domain/FollowList/Follower/index.tsx
@@ -12,6 +12,7 @@ import PublicApi from '@/apis/domain/Public/PublicApi';
 import { useRecoilValue } from 'recoil';
 import { userId } from '@/utils/recoil/atom';
 import Spinner from '@/components/Spinner';
+import useEffectAfterMount from '@/hooks/useEffectAfterMount';
 
 interface followerProps {
   setSelectedUserName: Dispatch<SetStateAction<string>>;
@@ -103,7 +104,7 @@ export default function Follower({
     setAlertOpen(true);
   };
 
-  useEffect(() => {
+  useEffectAfterMount(() => {
     reset();
   }, [keyword]);
 

--- a/components/Domain/FollowList/Following/index.tsx
+++ b/components/Domain/FollowList/Following/index.tsx
@@ -59,7 +59,7 @@ export default function Following({
       page,
       size,
       name: keyword,
-      userId: Number(router.query.UserId![0]),
+      userId: Number(router.query.UserId ?? [0]),
     });
     return data;
   };
@@ -77,11 +77,11 @@ export default function Following({
     fetchDataFunction,
     initialData: [],
     size: 20,
-    key: `following-${Number(router.query.UserId![0])}`,
+    key: `following-${Number(router.query.UserId ?? [0])}`,
   });
 
   useRememberScroll({
-    key: `following-${Number(router.query.UserId![0])}`,
+    key: `following-${Number(router.query.UserId ?? [0])}`,
     containerRef,
     setList: setFollowingList,
     list: followingList,

--- a/components/Domain/FollowList/Following/index.tsx
+++ b/components/Domain/FollowList/Following/index.tsx
@@ -10,6 +10,7 @@ import { UserApi } from '@/apis/domain/User/UserApi';
 import NextImage from '@/components/NextImage';
 import Avatar from '@/public/images/Avatar.svg';
 import Spinner from '@/components/Spinner';
+import useEffectAfterMount from '@/hooks/useEffectAfterMount';
 
 interface followingProps {
   followingList: followListType[];
@@ -89,7 +90,7 @@ export default function Following({
     setFollowingList(newData);
   }, [data]);
 
-  useEffect(() => {
+  useEffectAfterMount(() => {
     reset();
   }, [keyword]);
 

--- a/components/Domain/FollowList/Following/index.tsx
+++ b/components/Domain/FollowList/Following/index.tsx
@@ -11,6 +11,7 @@ import NextImage from '@/components/NextImage';
 import Avatar from '@/public/images/Avatar.svg';
 import Spinner from '@/components/Spinner';
 import useEffectAfterMount from '@/hooks/useEffectAfterMount';
+import useRememberScroll from '@/hooks/useRememberScroll';
 
 interface followingProps {
   followingList: followListType[];
@@ -76,6 +77,14 @@ export default function Following({
     fetchDataFunction,
     initialData: [],
     size: 20,
+    key: `following-${Number(router.query.UserId![0])}`,
+  });
+
+  useRememberScroll({
+    key: `following-${Number(router.query.UserId![0])}`,
+    containerRef,
+    setList: setFollowingList,
+    list: followingList,
   });
 
   useEffect(() => {

--- a/components/Domain/Main/Explore/index.tsx
+++ b/components/Domain/Main/Explore/index.tsx
@@ -1,5 +1,5 @@
 import S from './style';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import useInfiniteScroll from '@/hooks/useInfiniteScroll';
 import { OOTDApi } from '@/apis/domain/OOTD/OOTDApi';
@@ -66,7 +66,7 @@ export default function Explore() {
   });
 
   //탐색 리스트 조회 api 호출 완료 시 ootdList 상태 업데이트
-  useEffectAfterMount(() => {
+  useEffect(() => {
     setOOTDList(
       OOTDData.map((item: any) => {
         return {

--- a/hooks/useInfiniteScroll.tsx
+++ b/hooks/useInfiniteScroll.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import useEffectAfterMount from './useEffectAfterMount';
 import { ClipLoader } from 'react-spinners';
+import { useRouter } from 'next/router';
 
 interface InfiniteScrollProps {
   fetchDataFunction: any;
@@ -26,7 +27,7 @@ export default function useInfiniteScroll({
   const [total, setTotal] = useState<number>(0);
   const [pullDistance, setPullDistance] = useState<number>(0);
   const [isPulling, setIsPulling] = useState<Boolean>(false);
-
+  const router = useRouter();
   const containerRef = useRef<any>(null);
   const startY = useRef<number | null>(null);
 
@@ -56,6 +57,7 @@ export default function useInfiniteScroll({
 
   //초기 데이터 패칭
   useEffect(() => {
+    if (!router.isReady) return;
     if (initialData?.length > 0) {
       fetchDataFunction(0, 1).then((response: any) => {
         setTotal(response.total);
@@ -63,7 +65,7 @@ export default function useInfiniteScroll({
       return;
     }
     fetchData(page, size);
-  }, []);
+  }, [router.isReady]);
 
   //추가 데이터 패칭
   useEffect(() => {

--- a/hooks/useInfiniteScroll.tsx
+++ b/hooks/useInfiniteScroll.tsx
@@ -21,7 +21,7 @@ export default function useInfiniteScroll({
 }: InfiniteScrollProps) {
   const [page, setPage] = useState<number>(initialPage ? initialPage : 0);
   const [data, setData] = useState(initialData);
-  const [hasNextPage, setHasNextPage] = useState<Boolean>(false);
+  const [hasNextPage, setHasNextPage] = useState<Boolean>(true);
   const [isLoading, setIsLoading] = useState<Boolean>(false);
   const [isRefreshing, setIsRefreshing] = useState<Boolean>(false);
   const [total, setTotal] = useState<number>(0);
@@ -30,7 +30,6 @@ export default function useInfiniteScroll({
 
   const containerRef = useRef<any>(null);
   const startY = useRef<number | null>(null);
-  const router = useRouter();
 
   const fetchData = async (
     pageNum: number,
@@ -56,15 +55,22 @@ export default function useInfiniteScroll({
     return result;
   };
 
+  //초기 데이터 패칭
   useEffect(() => {
-    if (!router.isReady) return;
+    if (initialData?.length > 0) {
+      fetchDataFunction(0, 1).then((response: any) => {
+        setTotal(response.total);
+      });
+      return;
+    }
     fetchData(page, size);
-  }, [router.isReady]);
+  }, []);
 
+  //추가 데이터 패칭
   useEffect(() => {
     if (!hasNextPage || !isLoading) return;
     fetchData(page, size).then(() => setIsLoading(false));
-  }, [isLoading, hasNextPage]);
+  }, [isLoading]);
 
   const handleScroll = () => {
     const container = containerRef.current;

--- a/hooks/useInfiniteScroll.tsx
+++ b/hooks/useInfiniteScroll.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useRouter } from 'next/router';
 import { useEffect, useRef, useState, useCallback } from 'react';
 import useEffectAfterMount from './useEffectAfterMount';
 import { ClipLoader } from 'react-spinners';
@@ -68,7 +67,10 @@ export default function useInfiniteScroll({
 
   //추가 데이터 패칭
   useEffect(() => {
-    if (!hasNextPage || !isLoading) return;
+    if (!hasNextPage || !isLoading) {
+      setIsLoading(false);
+      return;
+    }
     fetchData(page, size).then(() => setIsLoading(false));
   }, [isLoading]);
 
@@ -145,6 +147,7 @@ export default function useInfiniteScroll({
   }, [handleTouchStart, handleTouchMove, handleTouchEnd]);
 
   const moreFetch = useCallback(() => {
+    setHasNextPage(true);
     setIsLoading(true);
   }, []);
 

--- a/hooks/useRememberScroll.tsx
+++ b/hooks/useRememberScroll.tsx
@@ -22,8 +22,6 @@ export default function useRememberScroll({
     const container = containerRef.current;
     if (!container) return;
 
-    if (!container) return;
-
     //세션 스토리지에 스크롤 저장 함수 (데이터 불러오기 전 스크롤 위치 이동을 막기 위한 컴포넌트 높이 저장)
     const handleScroll = () => {
       const { scrollTop, scrollHeight } = container;


### PR DESCRIPTION
# 🔢 이슈 번호

- #541 

## ⚙ 작업 사항

- [x] 팔로잉 팔로워 스크롤 관련 버그 수정
- [x] 스크롤 기억 훅이 적용되어 있지 않은 페이지 수정
- [x] 스크롤이 맨 아래 닿은 후 당겨서 새로고침 시 무한 로딩이 걸리는 버그 수정
- [x] fetcher의 timeout 제거
- [x] 라우팅이 완료된 후 무한 스크롤이 작동하도록 수정

## 📃 참고자료

-

## 📷 스크린샷
